### PR TITLE
pygmentsCodefences=true

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -5,6 +5,7 @@ title = "Mattermost Developers"
 languageCode = "en-us"
 theme = "hugo-elate-theme"
 publishDir = "../docs"
+pygmentsCodefences = true
 
 [params]
 


### PR DESCRIPTION
Syntax highlighting just isn't enabled by default for markdown (https://gohugo.io/content-management/syntax-highlighting/#highlight-in-code-fences).

🎉  http://mattermost-developer-documentation.s3-website-us-east-1.amazonaws.com/branches/syntax-highlighting/extend/server/hello-world/

Closes #13 