### PR TITLE
Add server api reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # build artifacts
 /dist
+/site/data/PluginGoDocs.json
 
 # os artifacts
 *.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 dist: trusty
 sudo: false
 language: go
-go:
-  - 1.x
+go: 1.x
 before_install:
   - mkdir bin
   - export PATH=$PATH:$PWD/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 dist: trusty
 sudo: false
+language: go
+go:
+  - 1.x
 before_install:
   - mkdir bin
   - export PATH=$PATH:$PWD/bin

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-.PHONY: dist
+.PHONY: dist plugin-godocs
 
-dist:
+dist: plugin-godocs
 	rm -rf ./dist
 	cd site && hugo --destination ../dist/html
+
+plugin-godocs:
+	go get -u -v github.com/mattermost/mattermost-server/plugin
+	mkdir -p site/data
+	go run scripts/plugin-godocs.go > site/data/PluginGoDocs.json

--- a/scripts/plugin-godocs.go
+++ b/scripts/plugin-godocs.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"encoding/json"
+	"go/ast"
+	"go/build"
+	"go/doc"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+)
+
+type Field struct {
+	Names []string `json:"Names,omitempty"`
+	Type  string
+}
+
+type MethodDocs struct {
+	Name       string
+	Comment    string
+	Parameters []*Field `json:"Parameters,omitempty"`
+	Results    []*Field `json:"Results,omitempty"`
+}
+
+type InterfaceDocs struct {
+	Comment string
+	Methods []*MethodDocs
+}
+
+type Docs struct {
+	API   InterfaceDocs
+	Hooks InterfaceDocs
+}
+
+var singleCommentNewline *regexp.Regexp = regexp.MustCompile("([^\n])\n([^\n])")
+
+func cleanComment(comment string) string {
+	return strings.TrimSpace(singleCommentNewline.ReplaceAllString(comment, "$1 $2"))
+}
+
+func fields(list *ast.FieldList, info *types.Info) (fields []*Field) {
+	if list != nil {
+		for _, x := range list.List {
+			field := &Field{
+				Type: info.TypeOf(x.Type).String(),
+			}
+			for _, name := range x.Names {
+				field.Names = append(field.Names, name.Name)
+			}
+			fields = append(fields, field)
+		}
+	}
+	return
+}
+
+func typeCheck(pkg *ast.Package, path string, fset *token.FileSet) (*types.Info, error) {
+	typeConfig := types.Config{Importer: importer.For("source", nil)}
+	info := &types.Info{
+		Types: make(map[ast.Expr]types.TypeAndValue),
+		Uses:  make(map[*ast.Ident]types.Object),
+		Defs:  make(map[*ast.Ident]types.Object),
+	}
+	var files []*ast.File
+	for _, file := range pkg.Files {
+		files = append(files, file)
+	}
+	_, err := typeConfig.Check(path, fset, files, info)
+	return info, err
+}
+
+func generateDocs() (*Docs, error) {
+	imp, err := build.Import("github.com/mattermost/mattermost-server/plugin", "", 0)
+	if err != nil {
+		return nil, err
+	}
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, imp.Dir, nil, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	var docs Docs
+
+	for path, pkg := range pkgs {
+		info, err := typeCheck(pkg, "github.com/mattermost/mattermost-server/"+path, fset)
+		if err != nil {
+			return nil, err
+		}
+
+		godocs := doc.New(pkg, path, 0)
+		for _, t := range godocs.Types {
+			var interfaceDocs *InterfaceDocs
+			switch t.Name {
+			case "API":
+				interfaceDocs = &docs.API
+			case "Hooks":
+				interfaceDocs = &docs.Hooks
+			default:
+				continue
+			}
+			interfaceDocs.Comment = cleanComment(t.Doc)
+			for _, spec := range t.Decl.Specs {
+				typeSpec, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				iface, ok := typeSpec.Type.(*ast.InterfaceType)
+				if !ok {
+					continue
+				}
+				for _, method := range iface.Methods.List {
+					f := method.Type.(*ast.FuncType)
+					methodDocs := &MethodDocs{
+						Name:       method.Names[0].Name,
+						Comment:    cleanComment(method.Doc.Text()),
+						Parameters: fields(f.Params, info),
+						Results:    fields(f.Results, info),
+					}
+					interfaceDocs.Methods = append(interfaceDocs.Methods, methodDocs)
+				}
+			}
+		}
+	}
+
+	return &docs, nil
+}
+
+func main() {
+	docs, err := generateDocs()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	b, err := json.MarshalIndent(docs, "", "    ")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	os.Stdout.Write(b)
+}

--- a/site/content/extend/server/api-reference.md
+++ b/site/content/extend/server/api-reference.md
@@ -1,8 +1,0 @@
----
-title: API Reference
-date: 2017-10-26T17:54:54-05:00
-subsection: server
-weight: 10
----
-
-The server API for plugins can be found on [GoDoc](https://godoc.org/github.com/mattermost/mattermost-server/plugin).

--- a/site/content/extend/server/hello-world.md
+++ b/site/content/extend/server/hello-world.md
@@ -23,26 +23,7 @@ Run this command to download the source code for the Mattermost server: `go get 
 
 Now, create a directory to act as your workspace, and create a file named "plugin.go" inside of it with the following contents:
 
-```go
-package main
-
-import (
-	"fmt"
-	"net/http"
-
-	"github.com/mattermost/mattermost-server/plugin/rpcplugin"
-)
-
-type MyPlugin struct{}
-
-func (p *MyPlugin) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
-	fmt.Fprintf(w, "Hello, world!")
-}
-
-func main() {
-	rpcplugin.Main(&MyPlugin{})
-}
-```
+{{<plugingoexamplecode name="_helloWorld">}}
 
 This plugin will register an HTTP handler that will respond with "Hello, world!" when requested.
 

--- a/site/content/extend/server/reference.md
+++ b/site/content/extend/server/reference.md
@@ -5,6 +5,7 @@ subsection: server
 weight: 10
 ---
 
-Below is the documentation for the two main mechanisms used by server plugins, the API and hooks. All of this documentation can also be found on [GoDoc](https://godoc.org/github.com/mattermost/mattermost-server/plugin).
+#### This is the documentation for the Go <code>github.com/mattermost/mattermost-server/plugin</code> package. It can also be found on [GoDoc](https://godoc.org/github.com/mattermost/mattermost-server/plugin).
+***
 
 {{<plugingodocs>}}

--- a/site/content/extend/server/reference.md
+++ b/site/content/extend/server/reference.md
@@ -1,0 +1,10 @@
+---
+title: Reference
+date: 2017-10-26T17:54:54-05:00
+subsection: server
+weight: 10
+---
+
+Below is the documentation for the two main mechanisms used by server plugins, the API and hooks. All of this documentation can also be found on [GoDoc](https://godoc.org/github.com/mattermost/mattermost-server/plugin).
+
+{{<plugingodocs>}}

--- a/site/layouts/shortcodes/plugingodocs.html
+++ b/site/layouts/shortcodes/plugingodocs.html
@@ -39,22 +39,16 @@
 {{ end }}
 
 {{ define "ParenthesizedResults" }}
-    {{- if .Remaining -}}
-        {{- $nextFieldCount := or (index .Remaining 0).Names (slice "_") | len -}}
-        {{- if gt (len .Remaining) 1 -}}
-            {{- template "ParenthesizedResults" dict "Count" (add .Count $nextFieldCount) "HTML" .HTML "Remaining" (after 1 .Remaining) "Results" .Results -}}
-        {{- else -}}
-            {{- template "ParenthesizedResults" dict "Count" (add .Count $nextFieldCount) "HTML" .HTML "Remaining" (slice) "Results" .Results -}}
-        {{- end -}}
-    {{- else -}}
-        {{- if gt .Count 1 }}({{ end -}}
+    {{- if .Results -}}
+        {{- $needsParentheses := or (gt (len .Results) 1) (index .Results 0).Names -}}
+        {{- if $needsParentheses }}({{ end -}}
         {{- if .HTML }}{{ template "FieldsHTML" .Results }}{{ else }}{{ template "FieldsString" .Results }}{{ end -}}
-        {{- if gt .Count 1 }}){{ end -}}
+        {{- if $needsParentheses }}){{ end -}}
     {{- end -}}
 {{ end }}
 
-{{ define "ResultsString" }}{{ template "ParenthesizedResults" dict "Count" 0 "HTML" false "Remaining" . "Results" . }}{{ end }}
-{{ define "ResultsHTML" }}{{ template "ParenthesizedResults" dict "Count" 0 "HTML" true "Remaining" . "Results" . }}{{ end }}
+{{ define "ResultsString" }}{{ template "ParenthesizedResults" dict "HTML" false "Results" . }}{{ end }}
+{{ define "ResultsHTML" }}{{ template "ParenthesizedResults" dict "HTML" true "Results" . }}{{ end }}
 
 {{ define "FunctionSignatureHTML" }}
     <pre><code>

--- a/site/layouts/shortcodes/plugingodocs.html
+++ b/site/layouts/shortcodes/plugingodocs.html
@@ -1,0 +1,101 @@
+{{ $docs := .Site.Data.PluginGoDocs }}
+
+{{ define "TypeString" }}
+    {{- if hasPrefix . "[]" }}[]{{ template "TypeString" (strings.TrimPrefix "[]" .) }}
+    {{- else if hasPrefix . "*"}}*{{ template "TypeString" (strings.TrimPrefix "*" .) }}
+    {{- else }}{{ index (split . "/" | last 1) 0 }}
+    {{- end -}}
+{{ end }}
+
+{{ define "TypeHTML" }}
+    {{- $builtInTypes := slice "bool" "byte" "complex128" "complex64" "error" "float32" "float64" "int" "int16" "int32" "int64" "int8" "rune" "string" "uint" "uint16" "uint32" "uint64" "uint8" "uintptr" -}}
+    {{- if in $builtInTypes . }}<a href="https://godoc.org/builtin#{{ . }}">{{ . }}</a>
+    {{- else if hasPrefix . "[]" }}[]{{ template "TypeHTML" (strings.TrimPrefix "[]" .) }}
+    {{- else if hasPrefix . "*" }}*{{ template "TypeHTML" (strings.TrimPrefix "*" .) }}
+    {{- else if in . "." -}}
+        {{- $name := index (split . "." | last 1) 0 }}
+        {{- $package := strings.TrimSuffix $name . | strings.TrimSuffix "." -}}
+        <a href="https://godoc.org/{{ $package }}" target="_blank">{{ index (split $package "/" | last 1) 0 }}</a>.<a href="https://godoc.org/{{ $package }}#{{ $name }}" target="_blank">{{ $name }}</a>
+    {{- else }}{{ range split . "/" | last 1 }}{{ . }}{{ end }}
+    {{- end -}}
+{{ end }}
+
+{{ define "FieldsString" }}
+    {{- if . -}}
+        {{- range $index, $field := . -}}
+            {{- if ne $index 0 }}, {{ end -}}
+            {{- if $field.Names }}{{ delimit $field.Names ", " }} {{ end }}{{ template "TypeString" $field.Type -}}
+        {{- end -}}
+    {{- end -}}
+{{ end }}
+
+{{ define "FieldsHTML" }}
+    {{- if . -}}
+        {{- range $index, $field := . -}}
+            {{- if ne $index 0 }}, {{ end -}}
+            {{- if $field.Names }}{{ delimit $field.Names ", " }} {{ end }}{{ template "TypeHTML" $field.Type -}}
+        {{- end -}}
+    {{- end -}}
+{{ end }}
+
+{{ define "ParenthesizedResults" }}
+    {{- if .Remaining -}}
+        {{- $nextFieldCount := or (index .Remaining 0).Names (slice "_") | len -}}
+        {{- if gt (len .Remaining) 1 -}}
+            {{- template "ParenthesizedResults" dict "Count" (add .Count $nextFieldCount) "HTML" .HTML "Remaining" (after 1 .Remaining) "Results" .Results -}}
+        {{- else -}}
+            {{- template "ParenthesizedResults" dict "Count" (add .Count $nextFieldCount) "HTML" .HTML "Remaining" (slice) "Results" .Results -}}
+        {{- end -}}
+    {{- else -}}
+        {{- if gt .Count 1 }}({{ end -}}
+        {{- if .HTML }}{{ template "FieldsHTML" .Results }}{{ else }}{{ template "FieldsString" .Results }}{{ end -}}
+        {{- if gt .Count 1 }}){{ end -}}
+    {{- end -}}
+{{ end }}
+
+{{ define "ResultsString" }}{{ template "ParenthesizedResults" dict "Count" 0 "HTML" false "Remaining" . "Results" . }}{{ end }}
+{{ define "ResultsHTML" }}{{ template "ParenthesizedResults" dict "Count" 0 "HTML" true "Remaining" . "Results" . }}{{ end }}
+
+{{ define "FunctionSignatureHTML" }}
+    <pre><code>
+        {{- .Name }}({{ template "FieldsHTML" .Parameters }}) {{ template "ResultsHTML" .Results -}}
+    </code></pre>
+{{ end }}
+
+{{ define "InterfaceTOC" }}
+    <ul>
+        {{ range .Interface.Methods }}
+        <li><a href="#{{ $.Name}}.{{ .Name }}">{{ .Name }}({{ template "FieldsString" .Parameters }}) {{ template "ResultsString" .Results }}</a></li>
+        {{ end }}
+    </ul>
+{{ end }}
+
+{{ define "InterfaceMethodDocs" }}
+    {{ range .Interface.Methods }}
+        <div>
+            <h1 id="{{ $.Name }}.{{ .Name }}">({{ $.Name }}) {{ .Name }}</h1>
+            <p>{{ template "FunctionSignatureHTML" . }}</p>
+            <p>{{ markdownify .Comment }}</p>
+        </div>
+    {{ end }}
+{{ end }}
+
+{{ if $docs }}
+    <div>
+        <div>
+            <h1>API</h1>
+            <p>{{ markdownify $docs.API.Comment }}</p>
+            {{ template "InterfaceTOC" dict "Name" "API" "Interface" $docs.API }}
+        </div>
+        <div>
+            <h1>Hooks</h1>
+            <p>{{ markdownify $docs.Hooks.Comment }}</p>
+            {{ template "InterfaceTOC" dict "Name" "Hooks" "Interface" $docs.Hooks }}
+        </div>
+        <hr />
+        {{ template "InterfaceMethodDocs" dict "Name" "API" "Interface" $docs.API }}
+        {{ template "InterfaceMethodDocs" dict "Name" "Hooks" "Interface" $docs.Hooks }}
+    </div>
+{{ else }}
+    Run <code>make plugin-godocs</code> to generate this documentation.
+{{ end }}

--- a/site/layouts/shortcodes/plugingodocs.html
+++ b/site/layouts/shortcodes/plugingodocs.html
@@ -59,7 +59,15 @@
 {{ define "InterfaceTOC" }}
     <ul>
         {{ range .Interface.Methods }}
-        <li><a href="#{{ $.Name}}.{{ .Name }}">{{ .Name }}({{ template "FieldsString" .Parameters }}) {{ template "ResultsString" .Results }}</a></li>
+        <li><a href="#{{ $.Name }}.{{ .Name }}">{{ .Name }}({{ template "FieldsString" .Parameters }}) {{ template "ResultsString" .Results }}</a></li>
+        {{ end }}
+    </ul>
+{{ end }}
+
+{{ define "ExamplesTOC" }}
+    <ul>
+        {{ range $name, $example := . }}
+        <li><a href="#Examples.{{ $name }}">{{ substr $name 1 1 | upper }}{{ substr (strings.TrimPrefix "_" $name) 1 }}</a></li>
         {{ end }}
     </ul>
 {{ end }}
@@ -74,22 +82,40 @@
     {{ end }}
 {{ end }}
 
+{{ define "ExampleDocs" }}
+    {{ range $name, $example := . }}
+        {{ if hasPrefix $name "_" }}
+            <div>
+                <h1 id="Examples.{{ $name }}">Example: {{ substr $name 1 1 | upper }}{{ substr (strings.TrimPrefix "_" $name) 1 }}</h1>
+                <p>{{ markdownify $example.Comment }}</p>
+                <p>{{ highlight $example.Code "go" "" }}</p>
+            </div>
+        {{ end }}
+    {{ end }}
+{{ end }}
+
 {{ if $docs }}
+    <p>{{ markdownify $docs.Comment }}</p>
     <div>
-        <div>
-            <h1>API</h1>
-            <p>{{ markdownify $docs.API.Comment }}</p>
-            {{ template "InterfaceTOC" dict "Name" "API" "Interface" $docs.API }}
-        </div>
-        <div>
-            <h1>Hooks</h1>
-            <p>{{ markdownify $docs.Hooks.Comment }}</p>
-            {{ template "InterfaceTOC" dict "Name" "Hooks" "Interface" $docs.Hooks }}
-        </div>
-        <hr />
-        {{ template "InterfaceMethodDocs" dict "Name" "API" "Interface" $docs.API }}
-        {{ template "InterfaceMethodDocs" dict "Name" "Hooks" "Interface" $docs.Hooks }}
+        <h1>API</h1>
+        <p>{{ markdownify $docs.API.Comment }}</p>
+        {{ template "InterfaceTOC" dict "Name" "API" "Interface" $docs.API }}
     </div>
+    <div>
+        <h1>Hooks</h1>
+        <p>{{ markdownify $docs.Hooks.Comment }}</p>
+        {{ template "InterfaceTOC" dict "Name" "Hooks" "Interface" $docs.Hooks }}
+    </div>
+    <div>
+        <h1>Examples</h1>
+        {{ template "ExamplesTOC" $docs.Examples }}
+    </div>
+    <hr />
+    {{ template "InterfaceMethodDocs" dict "Name" "API" "Interface" $docs.API }}
+    <hr />
+    {{ template "InterfaceMethodDocs" dict "Name" "Hooks" "Interface" $docs.Hooks }}
+    <hr />
+    {{ template "ExampleDocs" $docs.Examples }}
 {{ else }}
     Run <code>make plugin-godocs</code> to generate this documentation.
 {{ end }}

--- a/site/layouts/shortcodes/plugingoexamplecode.html
+++ b/site/layouts/shortcodes/plugingoexamplecode.html
@@ -1,0 +1,8 @@
+{{ $docs := .Site.Data.PluginGoDocs }}
+
+{{ if $docs }}
+    {{ $example := .Get "name" | index $docs.Examples }}
+    {{ highlight $example.Code "go" "" }}
+{{ else }}
+    Run <code>make plugin-godocs</code> to generate this example code.
+{{ end }}


### PR DESCRIPTION
Make target `go get`s the plugin package and runs a script to generate a JSON representation of the documentation. That JSON is put into the site/data directory, and is used by a layout to generate the HTML for the API reference:

http://mattermost-developer-documentation.s3-website-us-east-1.amazonaws.com/branches/add-server-api-reference/extend/server/reference/

If you just use `hugo server` without generating the docs, that page will just have some placeholder text telling you what to do.

It's just a start, but it's already more usable than GoDoc for this since GoDoc completely neglects documentation for interface methods. In addition to styling and more detailed docs, I'll definitely want an "introduced in version 4.X" tag on each method.

Also updated the Travis settings to build master daily, even if there are no new commits, so these docs will never be more than a day old.

Closes #17 