### PR TITLE
Add plugin manifest reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # build artifacts
 /dist
 /site/data/PluginGoDocs.json
+/site/data/PluginManifestDocs.json
 
 # os artifacts
 *.swp

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-.PHONY: dist plugin-godocs
+.PHONY: dist plugin-data
 
-dist: plugin-godocs
+dist: plugin-data
 	rm -rf ./dist
 	cd site && hugo --destination ../dist/html
 
-plugin-godocs:
+plugin-data:
 	go get -u -v github.com/mattermost/mattermost-server/plugin
 	mkdir -p site/data
 	go run scripts/plugin-godocs.go > site/data/PluginGoDocs.json
+	go run scripts/plugin-manifest-docs.go > site/data/PluginManifestDocs.json

--- a/scripts/plugin-godocs.go
+++ b/scripts/plugin-godocs.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 package main
 
 import (

--- a/scripts/plugin-manifest-docs.go
+++ b/scripts/plugin-manifest-docs.go
@@ -1,0 +1,203 @@
+// +build ignore
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"go/ast"
+	"go/build"
+	"go/doc"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"log"
+	"os"
+	"reflect"
+	"strings"
+)
+
+type Type string
+
+const (
+	Array  Type = "array"
+	Bool        = "bool"
+	Dict        = "dict"
+	Number      = "number"
+	Object      = "object"
+	String      = "string"
+)
+
+type ObjectProperty struct {
+	Name    string
+	DocHTML string    `json:"DocHTML,omitempty"`
+	Schema  *TypeDocs `json:"Schema,omitempty"`
+}
+
+type TypeDocs struct {
+	Type             Type
+	DocHTML          string            `json:"DocHTML,omitempty"`
+	ObjectProperties []*ObjectProperty `json:"ObjectProperties,omitempty"`
+	ValueSchema      *TypeDocs         `json:"ValueSchema,omitempty"`
+}
+
+type Docs struct {
+	Schema *TypeDocs
+}
+
+func typeCheck(pkg *ast.Package, path string, fset *token.FileSet) (*types.Info, error) {
+	typeConfig := types.Config{Importer: importer.For("source", nil)}
+	info := &types.Info{
+		Types: make(map[ast.Expr]types.TypeAndValue),
+		Uses:  make(map[*ast.Ident]types.Object),
+		Defs:  make(map[*ast.Ident]types.Object),
+	}
+	var files []*ast.File
+	for _, file := range pkg.Files {
+		files = append(files, file)
+	}
+	_, err := typeConfig.Check(path, fset, files, info)
+	return info, err
+}
+
+func typeSpec(t *doc.Type) *ast.TypeSpec {
+	for _, spec := range t.Decl.Specs {
+		if typeSpec, ok := spec.(*ast.TypeSpec); ok {
+			return typeSpec
+		}
+	}
+	return nil
+}
+
+func docTypeDocs(t *doc.Type, typesByName map[string]*doc.Type, info *types.Info) *TypeDocs {
+	ret := astTypeDocs(typeSpec(t).Type, typesByName, info)
+	if ret != nil {
+		buf := &bytes.Buffer{}
+		doc.ToHTML(buf, t.Doc, nil)
+		ret.DocHTML = buf.String()
+	}
+	return ret
+}
+
+func typesTypeDocs(t types.Type, typesByName map[string]*doc.Type, info *types.Info) *TypeDocs {
+	switch x := t.(type) {
+	case *types.Basic:
+		switch x.Kind() {
+		case types.String:
+			return &TypeDocs{
+				Type: String,
+			}
+		case types.Bool:
+			return &TypeDocs{
+				Type: Bool,
+			}
+		case types.Int, types.Int8, types.Int16, types.Int32, types.Int64, types.Uint,
+			types.Uint8, types.Uint16, types.Uint32, types.Uint64, types.Float32, types.Float64:
+			return &TypeDocs{
+				Type: Number,
+			}
+		}
+	case *types.Named:
+		if obj := x.Obj(); obj.Pkg().Path() == "github.com/mattermost/mattermost-server/model" {
+			if t, ok := typesByName[obj.Name()]; ok {
+				return docTypeDocs(t, typesByName, info)
+			}
+		}
+	}
+
+	log.Printf("unrecognized types.Type: %T, %v", t, t)
+	return nil
+}
+
+func astTypeDocs(expr ast.Expr, typesByName map[string]*doc.Type, info *types.Info) *TypeDocs {
+	switch x := expr.(type) {
+	case *ast.ArrayType:
+		return &TypeDocs{
+			Type:        Array,
+			ValueSchema: astTypeDocs(x.Elt, typesByName, info),
+		}
+	case *ast.StructType:
+		ret := &TypeDocs{
+			Type: Object,
+		}
+		for _, field := range x.Fields.List {
+			key := ""
+			if tag := field.Tag; tag != nil {
+				jsonTag := strings.Split(reflect.StructTag(strings.Trim(tag.Value, "`")).Get("json"), ",")
+				key = jsonTag[0]
+			}
+			if key == "" || key == "-" {
+				continue
+			}
+			buf := &bytes.Buffer{}
+			doc.ToHTML(buf, field.Doc.Text(), nil)
+			ret.ObjectProperties = append(ret.ObjectProperties, &ObjectProperty{
+				Name:    key,
+				DocHTML: buf.String(),
+				Schema:  astTypeDocs(field.Type, typesByName, info),
+			})
+		}
+		return ret
+	case *ast.SelectorExpr:
+		return astTypeDocs(x.Sel, typesByName, info)
+	case *ast.StarExpr:
+		return astTypeDocs(x.X, typesByName, info)
+	case *ast.Ident:
+		if t := info.TypeOf(x); t != nil {
+			return typesTypeDocs(t, typesByName, info)
+		}
+	case *ast.MapType:
+		return &TypeDocs{
+			Type:        Dict,
+			ValueSchema: astTypeDocs(x.Value, typesByName, info),
+		}
+	}
+
+	log.Printf("unrecognized ast.Expr: %T, %v", expr, expr)
+	return nil
+}
+
+func generateDocs() (*Docs, error) {
+	imp, err := build.Import("github.com/mattermost/mattermost-server/model", "", 0)
+	if err != nil {
+		return nil, err
+	}
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, imp.Dir, nil, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	pkg := pkgs["model"]
+	info, err := typeCheck(pkg, "github.com/mattermost/mattermost-server/model", fset)
+	if err != nil {
+		return nil, err
+	}
+
+	godocs := doc.New(pkg, "model", 0)
+
+	typesByName := make(map[string]*doc.Type)
+	for _, t := range godocs.Types {
+		typesByName[t.Name] = t
+	}
+
+	return &Docs{
+		Schema: docTypeDocs(typesByName["Manifest"], typesByName, info),
+	}, nil
+}
+
+func main() {
+	docs, err := generateDocs()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	b, err := json.MarshalIndent(docs, "", "    ")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	os.Stdout.Write(b)
+}

--- a/site/content/extend/example-plugins.md
+++ b/site/content/extend/example-plugins.md
@@ -2,6 +2,7 @@
 title: Example Plugins
 date: 2017-10-26T17:54:54-05:00
 section: extend
+weight: 40
 ---
 
 Construction

--- a/site/content/extend/manifest-reference.md
+++ b/site/content/extend/manifest-reference.md
@@ -1,0 +1,8 @@
+---
+title: Manifest Reference
+date: 2017-11-08T17:37:43-05:00
+section: extend
+weight: 30
+---
+
+{{<pluginmanifestdocs>}}

--- a/site/content/extend/server/_index.md
+++ b/site/content/extend/server/_index.md
@@ -2,6 +2,7 @@
 title: Extending the Server
 date: 2017-10-26T17:56:25-05:00
 section: extend
+weight: 10
 ---
 
 Plugins are capable of extending the Mattermost server by running processes on the server that interact with Mattermost via RPC.

--- a/site/content/extend/webapp/_index.md
+++ b/site/content/extend/webapp/_index.md
@@ -2,6 +2,7 @@
 title: Extending the Web App
 date: 2017-10-26T17:56:25-05:00
 section: extend
+weight: 20
 ---
 
 Web app plugins are capable of overriding and extending React UI components of the Mattermost web and desktop apps.

--- a/site/layouts/shortcodes/plugingodocs.html
+++ b/site/layouts/shortcodes/plugingodocs.html
@@ -117,5 +117,5 @@
     <hr />
     {{ template "ExampleDocs" $docs.Examples }}
 {{ else }}
-    Run <code>make plugin-godocs</code> to generate this documentation.
+    Run <code>make plugin-data</code> to generate this documentation.
 {{ end }}

--- a/site/layouts/shortcodes/pluginmanifestdocs.html
+++ b/site/layouts/shortcodes/pluginmanifestdocs.html
@@ -1,0 +1,40 @@
+{{ $docs := .Site.Data.PluginManifestDocs }}
+
+{{ define "ToC" }}
+    {{ if eq .Schema.Type "object" }}
+        <ul>
+            {{ range .Schema.ObjectProperties }}
+                <li><a href="#{{ $.Prefix }}{{ .Name }}">{{ .Name }}</a>{{ if .Schema }} - {{ title .Schema.Type }}{{ end }}</li>
+                {{ if .Schema }}{{ template "ToC" dict "Schema" .Schema "Prefix" (print $.Prefix .Name ".") }}{{ end }}
+            {{ end }}
+        </ul>
+    {{ else if eq .Schema.Type "array" | or (eq .Schema.Type "dict") }}
+        {{ if .Schema.ValueSchema }}{{ template "ToC" dict "Schema" .Schema.ValueSchema "Prefix" $.Prefix }}{{ end }}
+    {{ end }}
+{{ end }}
+
+{{ define "Docs" }}
+    {{ safeHTML .Schema.DocHTML }}
+    {{ if eq .Schema.Type "object" }}
+        <ul>
+            {{ range .Schema.ObjectProperties }}
+            <li id="{{ $.Prefix }}{{ .Name }}">
+                <p><tt>{{ .Name }}</tt>{{ if .Schema }} - {{ title .Schema.Type }}{{ end }}</p>
+                {{ safeHTML .DocHTML }}
+                {{ if .Schema }}{{ template "Docs" dict "Schema" .Schema "Prefix" (print $.Prefix .Name ".") }}{{ end }}
+            </li>
+            {{ end }}
+        </ul>
+    {{ else if eq .Schema.Type "array" | or (eq .Schema.Type "dict") }}
+        {{ if .Schema.ValueSchema }}{{ template "Docs" dict "Schema" .Schema.ValueSchema "Prefix" $.Prefix }}{{ end }}
+    {{ end }}
+{{ end }}
+
+{{ if $docs }}
+    <h1>Table of Contents</h1>
+    {{ template "ToC" dict "Schema" $docs.Schema "Prefix" "" }}
+    <h1>Reference</h1>
+    {{ template "Docs" dict "Schema" $docs.Schema "Prefix" "" }}
+{{ else }}
+    Run <code>make plugin-data</code> to generate this documentation.
+{{ end }}

--- a/site/layouts/shortcodes/pluginmanifestdocs.html
+++ b/site/layouts/shortcodes/pluginmanifestdocs.html
@@ -4,7 +4,7 @@
     {{ if eq .Schema.Type "object" }}
         <ul>
             {{ range .Schema.ObjectProperties }}
-                <li><a href="#{{ $.Prefix }}{{ .Name }}">{{ .Name }}</a>{{ if .Schema }} - {{ title .Schema.Type }}{{ end }}</li>
+                <li><a href="#{{ $.Prefix }}{{ .Name }}"><tt>{{ .Name }}</tt></a>{{ if .Schema }} - {{ title .Schema.Type }}{{ end }}</li>
                 {{ if .Schema }}{{ template "ToC" dict "Schema" .Schema "Prefix" (print $.Prefix .Name ".") }}{{ end }}
             {{ end }}
         </ul>
@@ -33,7 +33,7 @@
 {{ if $docs }}
     <h1>Table of Contents</h1>
     {{ template "ToC" dict "Schema" $docs.Schema "Prefix" "" }}
-    <h1>Reference</h1>
+    <h1>Documentation</h1>
     {{ template "Docs" dict "Schema" $docs.Schema "Prefix" "" }}
 {{ else }}
     Run <code>make plugin-data</code> to generate this documentation.


### PR DESCRIPTION
http://mattermost-developer-documentation.s3-website-us-east-1.amazonaws.com/branches/manifest-reference/extend/manifest-reference/

It's more useful with actual documentation (see https://github.com/mattermost/mattermost-server/pull/7806). Also needs styling. But it gets the important stuff there:

<img width="766" alt="screen shot 2017-11-09 at 12 17 54 am" src="https://user-images.githubusercontent.com/1731074/32591137-9146d7e6-c4e3-11e7-9d37-25e675f21c5a.png">
