### PR TITLE
Add after_deploy status, archive all commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,25 @@ before_install:
 script:
   - make dist
 deploy:
-  provider: s3
-  access_key_id: $AWS_ACCESS_KEY_ID
-  secret_access_key: $AWS_SECRET_ACCESS_KEY
-  bucket: mattermost-developer-documentation
-  local_dir: dist/html
-  upload-dir: branches/$TRAVIS_BRANCH
-  acl: public_read
-  skip_cleanup: true
-  on:
-    all_branches: true
+  - provider: s3
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    bucket: mattermost-developer-documentation
+    local_dir: dist/html
+    upload-dir: branches/$TRAVIS_BRANCH
+    acl: public_read
+    skip_cleanup: true
+    on:
+      all_branches: true
+  - provider: s3
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    bucket: mattermost-developer-documentation
+    local_dir: dist/html
+    upload-dir: commits/$TRAVIS_COMMIT
+    acl: public_read
+    skip_cleanup: true
+    on:
+      all_branches: true
+after_deploy:
+  - 'curl -H "Authorization: token $GITHUB_ACCESS_TOKEN" --data "{\"state\": \"success\", \"target_url\": \"http://mattermost-developer-documentation.s3-website-us-east-1.amazonaws.com/commits/$TRAVIS_COMMIT\", \"description\": \"Deployed to S3\", \"context\": \"continuous-integration/travis-ci/after-deploy\"}" "https://api.github.com/repos/mattermost/mattermost-developer-documentation/statuses/$TRAVIS_COMMIT"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ deploy:
     on:
       all_branches: true
 after_deploy:
-  - 'curl -H "Authorization: token $GITHUB_ACCESS_TOKEN" --data "{\"state\": \"success\", \"target_url\": \"http://mattermost-developer-documentation.s3-website-us-east-1.amazonaws.com/commits/$TRAVIS_COMMIT\", \"description\": \"Deployed to S3\", \"context\": \"continuous-integration/travis-ci/after-deploy\"}" "https://api.github.com/repos/mattermost/mattermost-developer-documentation/statuses/$TRAVIS_COMMIT"'
+  - 'curl -H "Authorization: token $GITHUB_ACCESS_TOKEN" --data "{\"state\": \"success\", \"target_url\": \"http://mattermost-developer-documentation.s3-website-us-east-1.amazonaws.com/commits/$TRAVIS_COMMIT\", \"description\": \"Deployed to S3\", \"context\": \"continuous-integration/s3-deploy\"}" "https://api.github.com/repos/mattermost/mattermost-developer-documentation/statuses/$TRAVIS_COMMIT"'


### PR DESCRIPTION
This deploys all commits to S3. Each commit deployed to S3 now gets a commit status where the details link takes you to the actual deployment. So instead of URL hacking when looking at your PRs, I can just click that. And I can go back in time and view past commits.

I've also added a lifecycle policy to the S3 bucket to move builds to infrequent access after 30 days and save us a few pennies.

Closes #28 