### PR TITLE
Add build infrastructure docs

### DIFF
--- a/site/content/internal/infrastructure/build.md
+++ b/site/content/internal/infrastructure/build.md
@@ -1,0 +1,33 @@
+---
+title: Build
+date: 2017-11-20T20:52:46-05:00
+subsection: internal
+---
+
+# Jenkins
+
+## [build.mattermost.com](https://build.mattermost.com/)
+
+Most of our automated builds currently take place on Jenkins at [build.mattermost.com](https://build.mattermost.com/).
+
+### Updating Go
+
+Builds on this Jenkins installation use a globally installed Golang distribution. To update it, you'll need to access the master instance and all of its slaves. Make sure the machine isn't in use, then run the following (replacing "1.9.2" with the desired Go version):
+
+```bash
+wget https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz
+sudo su
+rm -r /usr/local/go/
+tar -C /usr/local -xzf go1.9.2.linux-amd64.tar.gz
+export PATH=$PATH:/usr/local/go/bin
+env GOOS=windows GOARCH=amd64 go install std
+env GOOS=darwin GOARCH=amd64 go install std
+```
+
+## [newbuild.mattermost.com](https://newbuild.mattermost.com/)
+
+The Jenkins installation at [newbuild.mattermost.com](https://newbuild.mattermost.com/) is currently used only by the webapp build, but is intended to be the home of new builds that use more modern practices such as containerization and configuration as code via [Jenkins pipelines](https://jenkins.io/doc/book/pipeline/).
+
+# Travis CI
+
+Some light-weight, open source projects use [Travis CI](https://travis-ci.org/).


### PR DESCRIPTION
Primarily to get the Go upgrade process down in writing.

http://mattermost-developer-documentation.s3-website-us-east-1.amazonaws.com/branches/build-infra-docs/internal/infrastructure/build/