### PR TITLE
Update the core committers page

### DIFF
--- a/site/content/contribute/getting-started/core-committers.md
+++ b/site/content/contribute/getting-started/core-committers.md
@@ -43,7 +43,7 @@ Below is the list of core committers working on Mattermost:
   - Dev areas: Security, Integrations, Plugins, Server Architecture
 - **Jonathan Fritz**
   - `@jonathan` on [pre-release.mattermost.com](https://pre-release.mattermost.com/core/messages/@jonathan) and [@MusikPolice](https://github.com/MusikPolice) on GitHub
-  - Dev areas: Desktop, Message Export
+  - Dev areas: Desktop, Message Compliance
 - **Martin Kraft**
   - `@martin.kraft` on [pre-release.mattermost.com](https://pre-release.mattermost.com/core/messages/@martin.kraft) and [@mkraft](https://github.com/mkraft) on GitHub
   - Dev areas: React Native, Web App, Redux

--- a/site/content/contribute/getting-started/core-committers.md
+++ b/site/content/contribute/getting-started/core-committers.md
@@ -1,51 +1,54 @@
 ---
 draft: true
-title: "Core Developers"
+title: "Core Committers"
 date: 2017-08-20T12:33:36-04:00
 weight: 2
 subsection: Getting Started
 ---
 
-# Core Developers
+# Core Committers
 
-A core developer is a maintainer on the Mattermost project that has merge access to the Mattermost repositories. They are responsible for reviewing pull requests, cultivating the Mattermost developer community and guiding the technical vision of Mattermost. If you have a question or need some help, these are the people to ask.
+A core committer is a maintainer on the Mattermost project that has merge access to the Mattermost repositories. They are responsible for reviewing pull requests, cultivating the Mattermost developer community and guiding the technical vision of Mattermost. If you have a question or need some help, these are the people to ask.
 
-Below is the list of core developers working on Mattermost:
+Below is the list of core committers working on Mattermost:
 
 - **Corey Hulen**
   - `@corey` on [pre-release.mattermost.com](https://pre-release.mattermost.com/core/messages/@corey) and [@coreyhulen](https://github.com/coreyhulen) on GitHub
   - Dev areas: High Availability, Orchestration/Kubernetes, Push Proxy, Classic Mobile Apps
 - **Joram Wilander**
   - `@joram` on [pre-release.mattermost.com](https://pre-release.mattermost.com/core/messages/@joram) and [@jwilander](https://github.com/jwilander) on GitHub
-  - Dev areas: Webapp, Redux, REST API, Developer Toolkit, OAuth SSO, Statuses, WebSocket, Licensing
+  - Dev areas: Web App, Redux, REST API, Plugins, Integration, OAuth 2.0, WebSocket, Licensing
 - **Christopher Speller**
   - `@christopher` on [pre-release.mattermost.com](https://pre-release.mattermost.com/core/messages/@christopher) and [@crspeller](https://github.com/crspeller) on GitHub
-  - Dev areas: Performance, Security, Build, LDAP, Load Tests, Webpack, Permissions
+  - Dev areas: Performance, Security, Build, AD/LDAP, Load Tests, Webpack, Permissions
 - **Harrison Healey**
   - `@harrison` on [pre-release.mattermost.com](https://pre-release.mattermost.com/core/messages/@harrison) and [@hmhealey](https://github.com/hmhealey) on GitHub
-  - Dev areas: Markdown, React Native, Autocomplete, UI, Emojis, Reactions, Files
+  - Dev areas: Text Formatting, React Native, User Interface, Emojis, Reactions, Files
 - **Elias Nahum**
   - `@elias` on [pre-release.mattermost.com](https://pre-release.mattermost.com/core/messages/@elias) and [@enahum](https://github.com/enahum) on GitHub
-  - Dev areas: React Native, Redux, Localization, SAML, OAuth, WebRTC
+  - Dev areas: React Native, Redux, Localization, SAML, OAuth 2.0, WebRTC
 - **George Goldberg**
   - `@george` on [pre-release.mattermost.com](https://pre-release.mattermost.com/core/messages/@george) and [@grundleborg](https://github.com/grundleborg) on GitHub
-  - Dev areas: Import/Export (Slack, Bulk Loading, etc.), Diagnostics/Telemetry, Search, Permissions
+  - Dev areas: Import/Export (Slack, Bulk Loading, etc.), Diagnostics/Telemetry, Search, Permissions, Data Retention
 - **Saturnino Abril**
   - `@saturnino` on [pre-release.mattermost.com](https://pre-release.mattermost.com/core/messages/@saturnino) and [@saturninoabril](https://github.com/saturninoabril) on GitHub
-  - Dev areas: Webapp, REST API, UI Tests
+  - Dev areas: Web App, REST API, UI Tests
 - **Chris Duarte**
   - `@uberchris` on [pre-release.mattermost.com](https://pre-release.mattermost.com/core/messages/@uberchris) and [@csduarte](https://github.com/csduarte) on GitHub
 - **Carlos Panato**
   - `@cpanato` on [pre-release.mattermost.com](https://pre-release.mattermost.com/core/messages/@cpanato) and [@cpanato](https://github.com/cpanato) on GitHub
-  - Dev areas: Webapp, Redux, REST API, WebSocket Events
+  - Dev areas: Web App, Redux, REST API, WebSocket Events
 - **Chris Brown**
   - `@ccbrown` on [pre-release.mattermost.com](https://pre-release.mattermost.com/core/messages/@ccbrown) and [@ccbrown](https://github.com/ccbrown) on GitHub
-  - Dev areas: Security, Integrations, Plugins
+  - Dev areas: Security, Integrations, Plugins, Server Architecture
 - **Jonathan Fritz**
   - `@jonathan` on [pre-release.mattermost.com](https://pre-release.mattermost.com/core/messages/@jonathan) and [@MusikPolice](https://github.com/MusikPolice) on GitHub
-  - Dev areas: Desktop
+  - Dev areas: Desktop, Message Export
+- **Martin Kraft**
+  - `@martin.kraft` on [pre-release.mattermost.com](https://pre-release.mattermost.com/core/messages/@martin.kraft) and [@mkraft](https://github.com/mkraft) on GitHub
+  - Dev areas: React Native, Web App, Redux
 
-Below is the list of core developers working on individual Mattermost repositories:
+Below is the list of core committers working on individual Mattermost repositories:
 
 - **Yuya Ochiai** - [desktop](https://github.com/mattermost/desktop)
   - `@yuya-oc` on [pre-release.mattermost.com](https://pre-release.mattermost.com/core/messages/@yuya-oc) and [@yuya-oc](https://github.com/yuya-oc) on GitHub


### PR DESCRIPTION
Mainly just switching "core developers" to "core committers" to be in line with our other documentation and adding Martin.