### PR TITLE
 Add getting started section for integrations

### DIFF
--- a/site/content/integrate/getting-started/_index.md
+++ b/site/content/integrate/getting-started/_index.md
@@ -1,0 +1,12 @@
+---
+title: "Getting Started"
+date: "2017-08-19T12:01:23-04:00"
+section: "integrate"
+---
+
+# Getting Started
+
+{{< bignumber number="1" title="Sign up to our Mattermost site" content="Go to [pre-release.mattermost.com](https://pre-release.mattermost.com/signup_user_complete/?id=f1924a8db44ff3bb41c96424cdc20676) and join the [Developer Toolkit](https://pre-release.mattermost.com/core/channels/developer-toolkit) channel to ask questions." >}}
+{{< bignumber number="2" title="Choose an integration type" content="Read our [\"How Should I Integrate?\"](/integrate/getting-started/how-should-i-integrate) guide to pick integration points." >}}
+{{< bignumber number="3" title="Start developing" content="Use the information on this site and look at the [examples](/integrate/examples) for ideas on how to get started." >}}
+{{< bignumber number="4" title="Share your integration" content="Built something for Mattermost? We want to hear about it! [Let us know here](https://www.mattermost.org/share-your-mattermost-projects/)." >}}

--- a/site/content/integrate/getting-started/how-should-i-integrate.md
+++ b/site/content/integrate/getting-started/how-should-i-integrate.md
@@ -1,0 +1,36 @@
+---
+title: "How Should I Integrate?"
+date: 2017-08-20T12:33:36-04:00
+weight: 1
+subsection: Getting Started
+---
+
+# How Should I Integrate?
+
+Very good question! Mattermost has many different integration points and this page will help you pick the right one(s) for the job.
+
+### I just want to post into Mattermost
+
+If you only want to post messages into a Mattermost channel, then all you need is an [incoming webhook](/integrate/incoming-webhooks).
+
+### I want to know when someone says something
+
+Tracking what gets posted into a channel and receiving real-time events about it can be done using [outgoing webhooks](/integrate/outgoing-webhooks). You can also respond to messages with outgoing webhooks.
+
+### I want user interaction
+
+If you want your users to be able to trigger actions from within Mattermost, adding your own custom [slash command](/integrate/slash-commands) will do the trick.
+
+That not enough? You can include [interactive message buttons](/intergrate/message-attachments/interactive-message-buttons) in posts from your slash commands, as well as from incoming and outgoing webhooks.
+
+### I want to build an advanced bot
+
+To build a richer bot integration you can make full use of the [Mattermost REST API](/integrate/api). Everything you see a Mattermost client doing, your integration can do too with this API.
+
+### One of these alone isn't enough
+
+Good news! You can mix and match however many of these integration points you like to suit your needs. The choice is yours.
+
+### I still need more
+
+If these integration points aren't enough for what you had in mind, then take a look at [plugins](/extend/plugins/). They are very powerful and offer the ability to extend Mattermost in ways integrations can't.

--- a/site/layouts/shortcodes/bignumber.html
+++ b/site/layouts/shortcodes/bignumber.html
@@ -1,0 +1,11 @@
+<div class="steps-row">
+    <div class="steps-number">{{ .Get "number" }}</div>
+    <div>
+        <div>
+            <h4 class="steps-header">{{ .Get "title" }}</h4>
+        </div>
+        <div class="content">
+            {{ .Get "content" | markdownify }}
+        </div>
+    </div>
+</div>

--- a/site/static/css/styles.css
+++ b/site/static/css/styles.css
@@ -2686,3 +2686,24 @@ table > tbody > tr:nth-of-type(odd) {
   .homepage-boxes {
     margin-top: -13em; } }
 
+.steps-row {
+    display: flex;
+    margin-bottom: 25px;
+}
+
+.steps-number {
+    width: 50px;
+    height: 50px;
+    border-radius: 25px;
+    border: 1px solid #007bff;
+    display: flex;
+    flex-shrink: 0;
+    justify-content: center;
+    align-items: center;
+    margin-right: 35px;
+    color: #007bff;
+}
+
+.steps-header {
+    margin-bottom: 10px;
+}


### PR DESCRIPTION
Based off #89, so please only review the last commit

The two new pages can be seen here:
* http://mattermost-developer-documentation.s3-website-us-east-1.amazonaws.com/branches/integrate/integrate/getting-started/
* http://mattermost-developer-documentation.s3-website-us-east-1.amazonaws.com/branches/integrate/integrate/getting-started/how-should-i-integrate/

Note that some of the links are pointing to non-existent pages still