### PR TITLE
MM-10084 Add API reference section that redirects to api.mattermost.com

### DIFF
--- a/site/content/integrate/getting-started/how-should-i-integrate.md
+++ b/site/content/integrate/getting-started/how-should-i-integrate.md
@@ -25,7 +25,7 @@ That not enough? You can include [interactive message buttons](/intergrate/messa
 
 ### I want to build an advanced bot
 
-To build a richer bot integration you can make full use of the [Mattermost REST API](/integrate/api). Everything you see a Mattermost client doing, your integration can do too with this API.
+To build a richer bot integration you can make full use of the [Mattermost REST API](/integrate/rest-api). Everything you see a Mattermost client doing, your integration can do too with this API.
 
 ### One of these alone isn't enough
 

--- a/site/content/integrate/rest-api/_index.md
+++ b/site/content/integrate/rest-api/_index.md
@@ -1,0 +1,9 @@
+---
+title: "API Reference"
+date: "2017-01-19T12:01:23-04:00"
+section: "integrate"
+---
+
+Redirecting to api.mattermost.com
+
+<meta http-equiv="refresh" content="0; url=https://api.mattermost.com/" />


### PR DESCRIPTION
Originally I was going to write some more documentation and move some of it from api.mattermost.com but I couldn't think of a good way to divide the documentation between the reference and here. It didn't feel right to split it up into two places, and the API reference is already developer focused. So instead, I've opted to just redirect to api.mattermost.com

If someone has a better idea on how to organize the documentation for the API, I'm all ears

I used a redirect purposefully, so we can use links to the dev docs site in case we ever don't want it to redirect and have something different here