### PR TITLE
add blog entry for upgrading to npm-v6

### DIFF
--- a/site/content/blog/npm-v6.md
+++ b/site/content/blog/npm-v6.md
@@ -1,0 +1,20 @@
+---
+title: "npm@6"
+date: 2018-05-22T10:16:52-04:00
+draft: false
+categories:
+  - "announcement"
+---
+
+Heads up that with [PR#1239](https://github.com/mattermost/mattermost-webapp/pull/1239), we're effectively switching to [npm@6](https://medium.com/npm-inc/announcing-npm-6-5d0b1799a905).
+
+### Why the change?
+
+Previously, doing a fresh `npm install` would unexpectedly change `package-lock.json`. Upgrading to npm@6 should resolve this going forward.
+
+### What do I need to do?
+
+Make sure you're running npm@6:
+```bash
+npm install -g npm@6
+```


### PR DESCRIPTION
This is a <5 minute effort to replicate a recent announcement on pre-release for future consumption by our developer community.

The blog itself is not yet linked publicly, but can be accessed https://developers.mattermost.com/blog/. It's in need of some styling love, but it seems prudent to start writing "back articles" anyway.