### PR TITLE
fix emulator path

### DIFF
--- a/site/content/contribute/mobile/developer-setup.md
+++ b/site/content/contribute/mobile/developer-setup.md
@@ -85,9 +85,8 @@ Make sure you have the following ENV VARS configured:
 -   On Mac, this usually requires adding the following lines to your `~/.bash_profile` file:
 
     ```sh
-    export ANDROID_HOME=/Users/<username>/Library/Android/sdk
-    export PATH=$ANDROID_HOME/platform-tools:$PATH
-    export PATH=$ANDROID_HOME/tools:$PATH
+    export ANDROID_HOME=$HOME/Library/Android/sdk
+    export PATH=$ANDROID_HOME/emulator:$ANDROID_HOME/platform-tools:$ANDROID_HOME/tools:$PATH
     ```
 - Then reload your bash configuration:
 


### PR DESCRIPTION
Ensure `$ANDROID_HOME/emulator` is added to the `$PATH`, as the avd files are relative to the binary and the binary location seems to have [changed](https://stackoverflow.com/questions/26483370/android-emulator-error-message-panic-missing-emulator-engine-program-for-x86).

Also simplify the export to use `$HOME` directly.