### PR TITLE
Fixing redirect to MM issues on GitHub

### DIFF
--- a/site/content/contribute/getting-started/_index.md
+++ b/site/content/contribute/getting-started/_index.md
@@ -19,6 +19,6 @@ Our goal is to make your experience as best as possible. Follow these simple ste
 
 {{< bignumber number="3" title="Set up your developer machine" content="Each project has its own developer setup instructions. Find them in the sidebar on the left." >}}
 
-{{< bignumber number="4" title="Select a ticket" content="All help wanted tickets are under the [server repository's GitHub issues]((https://github.com/mattermost/mattermost-server/issues?q=is%3Aissue+is%3Aopen+label%3A%22Up+For+Grabs%22)). Comment to let everyone know you’re working on it. If there’s no ticket for what you want to work on see [contributions without a ticket.](/getting-started/contributions-without-ticket)" >}}
+{{< bignumber number="4" title="Select a ticket" content="All help wanted tickets are under the [server repository's GitHub issues](https://github.com/mattermost/mattermost-server/issues?q=is%3Aissue+is%3Aopen+label%3A%22Up+For+Grabs%22). Comment to let everyone know you’re working on it. If there’s no ticket for what you want to work on see [contributions without a ticket.](/getting-started/contributions-without-ticket)" >}}
 
 {{< bignumber number="5" title="Start developing" content="Each project has its own developer flow for tips on working with the Mattermost codebase. When your changes are ready, run through our [checklist for pull requests](/contribute/contribution-checklist). Note that if it’s your first contribution, there is a standard [CLA](https://www.mattermost.org/mattermost-contributor-agreement/) to sign." >}}


### PR DESCRIPTION
**Current:**
Select a ticket section with GitHub issues link incorrectly links to https://developers.mattermost.com/contribute/getting-started/(https://github.com/mattermost/mattermost-server/issues?q=is%3Aissue+is%3Aopen+label%3A%22Up+For+Grabs%22)

**Expected:**
Select a ticket section with GitHub issues should link to Mattermost issues that are Up For Grabs https://github.com/mattermost/mattermost-server/issues?q=is:issue+is:open+label:%22Up+For+Grabs%22