### PR TITLE
Document out of memory error in running mobile app

### DIFF
--- a/site/content/contribute/mobile/developer-setup.md
+++ b/site/content/contribute/mobile/developer-setup.md
@@ -154,25 +154,6 @@ In order to develop and build the Mattermost mobile apps you'll need to get a co
 
 ## Troubleshooting
 
-### Errors When Running 'make run'
-
-##### Error message
-```sh
-FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
-```
-
-##### Solution
--   Increase `max_old_space_size` of the nodejs instance.  On Mac, add the following line to your `~/.bash_profile` file:
-
-    ```sh
-    export NODE_OPTIONS=--max_old_space_size=12000
-    ```
-- Then reload your bash configuration:
-
-    ```sh
-    source ~/.bash_profile
-    ```
-
 ### Errors When Running 'make run-android'
 
 ##### Error message
@@ -248,3 +229,20 @@ ERROR:  While executing gem ... (Gem::Exception)
 Unable to require openssl, install OpenSSL and rebuild ruby (preferred) or use non-HTTPS sources
 ```
 - Run `make run-ios` again
+
+### Errors When Running 'react-native packager'
+
+##### Error message
+```sh
+FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
+```
+
+##### Solution
+- Increase `max_old_space_size` of the nodejs instance.
+    - On macOS, add the following line to your `~/.bash_profile` file: `export NODE_OPTIONS=--max_old_space_size=12000`
+
+- Then reload your bash configuration:
+
+    ```sh
+    source ~/.bash_profile
+    ```

--- a/site/content/contribute/mobile/developer-setup.md
+++ b/site/content/contribute/mobile/developer-setup.md
@@ -154,6 +154,25 @@ In order to develop and build the Mattermost mobile apps you'll need to get a co
 
 ## Troubleshooting
 
+### Errors When Running 'make run'
+
+##### Error message
+```sh
+FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
+```
+
+##### Solution
+-   Increase `max_old_space_size` of the nodejs instance.  On Mac, add the following line to your `~/.bash_profile` file:
+
+    ```sh
+    export NODE_OPTIONS=--max_old_space_size=12000
+    ```
+- Then reload your bash configuration:
+
+    ```sh
+    source ~/.bash_profile
+    ```
+
 ### Errors When Running 'make run-android'
 
 ##### Error message

--- a/site/content/contribute/mobile/developer-setup.md
+++ b/site/content/contribute/mobile/developer-setup.md
@@ -238,7 +238,7 @@ FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memo
 ```
 
 ##### Solution
-- Increase `max_old_space_size` of the nodejs instance.
+- Increase `max_old_space_size` of the NodeJS instance.
     - On macOS, add the following line to your `~/.bash_profile` file: `export NODE_OPTIONS=--max_old_space_size=12000`
 
 - Then reload your bash configuration:


### PR DESCRIPTION
Document out of memory error in running mobile app.

I've only encountered this on MacOS and I'm not sure how it goes with other OS.

<img width="832" alt="screen shot 2018-09-19 at 3 16 35 pm" src="https://user-images.githubusercontent.com/5334504/45736940-0a713700-bc1f-11e8-884d-6091fac8cd30.png">
