### PR TITLE
document migration through removal of auto-unmarshalling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 sudo: false
 language: go
-go: 1.x
+go: "1.11"
 env:
   - HUGO_VERSION="0.45.1"
 before_install:

--- a/site/content/extend/plugins/migration.md
+++ b/site/content/extend/plugins/migration.md
@@ -31,7 +31,7 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 }
 ```
 
-Unfortunately, writing to `Greeting` while the plugin may be concurrently reading from same could result in a corrupted read or write. The [mattermost-plugin-sample](https://github.com/mattermost/mattermost-plugin-sample) and [mattermost-plugin-demo](https://github.com/mattermost/mattermost-plugin-demo) have both been updated with more complete examples, but the general idea is to manually handle the `OnConfigurationChange` hook and synchronize access to these variables. One such way is with a [sync.RWMutex](https://golang.org/pkg/sync/#RWMutex):
+Writing to `Greeting` while the plugin may be concurrently reading from same could result in a corrupted read or write. The [mattermost-plugin-sample](https://github.com/mattermost/mattermost-plugin-sample) and [mattermost-plugin-demo](https://github.com/mattermost/mattermost-plugin-demo) have both been updated with more complete examples, but the general idea is to manually handle the `OnConfigurationChange` hook and synchronize access to these variables. One such way is with a [sync.RWMutex](https://golang.org/pkg/sync/#RWMutex):
 
 ```go
 type Plugin struct {


### PR DESCRIPTION
This accompanies the [server changes](https://github.com/mattermost/mattermost-server/pull/9519) to remove support for automatically unmarshalling a plugin's server configuration.

See also
* https://github.com/mattermost/mattermost-plugin-sample/pull/12
* https://github.com/mattermost/mattermost-plugin-demo/pull/7