### PR TITLE
Fix crash when running plugin-jsdocs.js

### DIFF
--- a/scripts/plugin-jsdocs.js
+++ b/scripts/plugin-jsdocs.js
@@ -15,7 +15,7 @@ const pluginRegistryClassMethods = registryParsed.body.find(statement =>
 ).map(statement => ({
     Name: statement.key.name,
     Parameters: statement.value.params.map(param => param.name),
-    Comments: statement.leadingComments.map(comment => comment.value.trim()),
+    Comments: statement.leadingComments ? statement.leadingComments.map(comment => comment.value.trim()) : [],
 }));
 
 output = {


### PR DESCRIPTION
Don't really know why the failure is pointing at my commit but it seems that somehow `statement.loadingComments` is undefined or null and thus causing a crash when running the script, this PR makes it so it does not crash.