### PR TITLE
link directly to the developer setup guide

### DIFF
--- a/site/content/contribute/server/developer-workflow.md
+++ b/site/content/contribute/server/developer-workflow.md
@@ -7,7 +7,7 @@ subsection: Server
 
 # Server Workflow
 
-If you haven't [set up your developer environment](https://docs.mattermost.com/developer/dev-setup.html), please do so before continuing with this section.
+If you haven't [set up your developer environment](https://developers.mattermost.com/contribute/server/developer-setup/), please do so before continuing with this section.
 
 Join the [Developers community channel](https://pre-release.mattermost.com/core/channels/developers) to ask questions from community members and the Mattermost core team.
 

--- a/site/content/contribute/webapp/developer-workflow.md
+++ b/site/content/contribute/webapp/developer-workflow.md
@@ -7,7 +7,7 @@ subsection: Web App
 
 # Web App Workflow
 
-If you haven't [set up your developer environment](https://docs.mattermost.com/developer/dev-setup.html), please do so before continuing with this section.
+If you haven't [set up your developer environment](https://developers.mattermost.com/contribute/webapp/developer-setup/), please do so before continuing with this section.
 
 ### Workflow ###
 


### PR DESCRIPTION
Currently, in the [Server](https://developers.mattermost.com/contribute/server/developer-workflow/) and [Web App](https://developers.mattermost.com/contribute/webapp/developer-workflow/) "Workflow" guides, there is copy to "set up your developer environment" which links to https://docs.mattermost.com/developer/dev-setup.html, which subsequently links the user back to the previous guide in the respective track ("Developer Setup"). This changes the markdown to link directly to the previous "Developer Setup" guide.