### PR TITLE
developer-setup: fixed formating and ping one-liner (to http w/o ssl)

### DIFF
--- a/site/content/contribute/server/developer-setup.md
+++ b/site/content/contribute/server/developer-setup.md
@@ -70,13 +70,10 @@ subsection: Server
     ```
 
 8. You can check if the server is running using the following `curl` command or opening the URL in your web browser:
-
    ```sh
-   curl https://localhost:8065/api/v4/system/ping
+   curl http://localhost:8065/api/v4/system/ping
    ```
-
    The server should return a JSON object containing `"status":"OK"`.
-
    **Notice:** The server root will return a `404 Not Found` status, since the web app is not configured as part of the server setup. Please refer to the [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for the setup steps.
 
 {{% /md %}}
@@ -158,13 +155,10 @@ subsection: Server
     ```
 
 8. You can check if the server is running using the following `curl` command or opening the URL in your web browser:
-
    ```sh
-   curl https://localhost:8065/api/v4/system/ping
+   curl http://localhost:8065/api/v4/system/ping
    ```
-
    The server should return a JSON object containing `"status":"OK"`.
-
    **Notice:** The server root will return a `404 Not Found` status, since the web app is not configured as part of the server setup. Please refer to the [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for the setup steps.
 
 {{% /md %}}
@@ -228,13 +222,10 @@ subsection: Server
     ```
 
 9. You can check if the server is running opening the following URL in your web browser:
-
    ```sh
-   https://localhost:8065/api/v4/system/ping
+   http://localhost:8065/api/v4/system/ping
    ```
-
    The server should return a JSON object containing `"status":"OK"`.
-
    **Notice:** The server root will return a `404 Not Found` status, since the web app is not configured as part of the server setup. Please refer to the [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for the setup steps.
 
 {{% /md %}}
@@ -300,13 +291,10 @@ Set up your development environment for building, running, and testing Mattermos
     ``git clone https://github.com/{username}/mattermost-webapp.git``
 
 1. You can check if the server is running using the following `curl` command or opening the URL in your web browser:
-
    ```sh
-   curl https://localhost:8065/api/v4/system/ping
+   curl http://localhost:8065/api/v4/system/ping
    ```
-
    The server should return a JSON object containing `"status":"OK"`.
-
    **Notice:** The server root will return a `404 Not Found` status, since the web app is not configured as part of the server setup. Please refer to the [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for the setup steps.
 
 ### Troubleshooting:
@@ -393,13 +381,10 @@ Now that everything is set up, you are ready to compile and run Mattermost.
     ```
 
 8. You can check if the server is running using the following `curl` command or opening the URL in your web browser:
-
    ```sh
-   curl https://localhost:8065/api/v4/system/ping
+   curl http://localhost:8065/api/v4/system/ping
    ```
-
    The server should return a JSON object containing `"status":"OK"`.
-
    **Notice:** The server root will return a `404 Not Found` status, since the web app is not configured as part of the server setup. Please refer to the [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for the setup steps.
 
 {{% /md %}}
@@ -492,13 +477,10 @@ Now that everything is set up, you are ready to compile and run Mattermost.
     ```
 
 8. You can check if the server is running using the following `curl` command or opening the URL in your web browser:
-
    ```sh
-   curl https://localhost:8065/api/v4/system/ping
+   curl http://localhost:8065/api/v4/system/ping
    ```
-
    The server should return a JSON object containing `"status":"OK"`.
-
    **Notice:** The server root will return a `404 Not Found` status, since the web app is not configured as part of the server setup. Please refer to the [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for the setup steps.
 
 {{% /md %}}


### PR DESCRIPTION
**Summary**
curl with https ran into SSL_ERROR_RX_RECORD_TOO_LONG error.

**Ticket Link**
N/A - contributing w/o ticket as this is a tiny change

**Checklist**
- [x] ran hugo locally and compiled successfully.