### PR TITLE
[MM-9937] [MM-9938] slash command response parameters update

### DIFF
--- a/site/content/integrate/slash-commands/_index.md
+++ b/site/content/integrate/slash-commands/_index.md
@@ -79,11 +79,12 @@ Slash command responses support more than just the `text` field. Here is a full 
 | text | [Markdown-formatted](https://docs.mattermost.com/help/messaging/formatting-text.html) message to display in the post. | If `attachments` is not set, yes |
 | response\_type | Set to blank or `ephemeral` to reply with a message that only the user can see. <br> Set to `in_channel` to create a regular message.<br> Defaults to `ephemeral`. | No |
 | username | Overrides the username the message posts as.<br> Defaults to the username set during webhook creation or the webhook creator's username if the former was not set.<br> Must be enabled [in the configuration](https://docs.mattermost.com/administration/config-settings.html#enable-integrations-to-override-usernames). | No |
+| channel\_id | Overrides the channel to which the message gets posted.<br> Defaults to the channel in which the command was issued. | No |
 | icon\_url | Overrides the profile picture the message posts with.<br> Defaults to the URL set during webhook creation or the webhook creator's profile picture if the former was not set.<br> Must be enabled [in the configuration](https://docs.mattermost.com/administration/config-settings.html#enable-integrations-to-override-profile-picture-icons). | No |
 | goto\_location | A URL to redirect the user to. Supports many protocols, including `http://`, `https://`, `ftp://`, `ssh://` and `mailto://`.| No |
 | attachments | [Message attachments](https://docs.mattermost.com/developer/message-attachments.html) used for richer formatting options. | If `text` is not set, yes |
 | type | Sets the post `type`, mainly for use by plugins.<br> If not blank, must begin with `custom_`. Passing `attachments` will ignore this field and set the type to `slack_attachment`. | No |
-| extra\_responses | Sends additional responses to channels listed in an array. These responses are processed as separate posts. All fields except for `goto_location` are applied. Available in Mattermost v5.6 and later. | No |
+| extra\_responses | An array of responses used to send more than one post in your response. Each item in this array takes the shape of its own command response, so it can include any of the other parameters listed here, except `goto\_location` and `extra\_responses` itself. Available in Mattermost v5.6 and later. | No |
 | props | Sets the post `props`, a JSON property bag for storing extra or meta data on the post.<br> Mainly used by other integrations accessing posts through the REST API.<br> The following keys are reserved: `from_webhook`, `override_username`, `override_icon_url` and `attachments`. | No |
 An example request using some more parameters would look like this:
 


### PR DESCRIPTION
These params were added per the following PRs:

https://github.com/mattermost/mattermost-server/pull/9878
https://github.com/mattermost/mattermost-server/pull/9836

I noticed that `trigger_id` is missing from the params in the documentation. Is this something that should be documented for custom slash commands?