### PR TITLE
Add edit link to pages

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -8,11 +8,11 @@ pygmentsCodeFences = true
 pygmentsStyle = "manni"
 
 [params]
-
   # Meta
   author = ""
   description = ""
   email = ""
+  ghrepo = "https://github.com/mattermost/mattermost-developer-documentation/"
 
   [params.mailinglist]
     enable = false

--- a/site/layouts/_default/list.html
+++ b/site/layouts/_default/list.html
@@ -15,6 +15,7 @@
             <div class="row">
                 {{ partial "sidebar.html" .}}
                 <div class="col-lg-9 doc-content">
+                    {{ partial "page-edit.html" . }}
                     {{ partial "hanchor.html" .Content }}
                 </div>
             </div>

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -15,6 +15,7 @@
             <div class="row">
                 {{ partial "sidebar.html" .}}
                 <div class="col-lg-9 doc-content">
+                    {{ partial "page-edit.html" . }}
                     {{ partial "hanchor.html" .Content }}
                 </div>
             </div>

--- a/site/layouts/partials/hanchor.html
+++ b/site/layouts/partials/hanchor.html
@@ -1,1 +1,1 @@
-{{ . | replaceRE "(<h[1-4] id=\"([^\"]+)\".+)(</h[2-9]+>)" `${1}&nbsp;<a class="hanchor fa fa-link" ariaLabel="Anchor" href="#${2}"></i></a> ${3}` | safeHTML }}
+{{ . | replaceRE "(<h[1-9] id=\"([^\"]+)\".+)(</h[1-9]+>)" `${1}&nbsp;<a class="hanchor fa fa-link" ariaLabel="Anchor" href="#${2}"></i></a> ${3}` | safeHTML }}

--- a/site/layouts/partials/page-edit.html
+++ b/site/layouts/partials/page-edit.html
@@ -1,0 +1,3 @@
+<a href="{{.Site.Params.ghrepo}}edit/master/site/content/{{.File.Path}}" class="float-right">
+  Edit on GitHub
+</a>


### PR DESCRIPTION
We could also add some kind of icon. But I don't have one. 

With the current code architecture its quite hard to align the link with the title. If this is wanted, I have to do some larger code changes.

Screenshot:
![screenshot from 2018-11-27 13-58-25](https://user-images.githubusercontent.com/16541325/49083376-b00edb00-f24c-11e8-9662-c8d4d44f619a.png)

Fixes #25 