### PR TITLE
Improve Notification Bar

### DIFF
--- a/site/layouts/partials/nav.html
+++ b/site/layouts/partials/nav.html
@@ -1,3 +1,5 @@
+{{ partial "notification.html" . }}
+
 <header>
     <a href="/"><img src="img/logo.svg" class="logo__colored" alt="Mattermost Logo" width="212px"></a>
     <a href="/"><img src="img/logo--white.svg" class="logo__white" alt="Mattermost Logo" width="212px"></a>
@@ -15,5 +17,3 @@
         {{ end }}
     </ul>
 </header>
-
-{{ partial "notification.html" .}}

--- a/site/layouts/partials/notification.html
+++ b/site/layouts/partials/notification.html
@@ -1,5 +1,10 @@
 {{ if .Site.Params.notification.enable }}
-<div class='notification-bar' style="">
-    <a href="{{ .Site.BaseURL}}{{ .Site.Params.notification.url }}">{{ .Site.Params.notification.text }}</a>
+<div class='notification-bar sticky-top'>
+    <button type="button" class="close notification-bar__close" data-dismiss="modal" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+    </button>
+    <a href="{{ .Site.Params.notification.url | absURL }}">
+        {{ .Site.Params.notification.text }}
+    </a>
 </div>
 {{ end }}

--- a/site/static/css/bar.css
+++ b/site/static/css/bar.css
@@ -1,45 +1,15 @@
 .notification-bar {
     background-color: purple;
     color: white;
-    padding: 5px 30px;
-    position: fixed;
+    padding: 5px 15px;
     text-align: center;
-    top: 0;
     width: 100%;
-    z-index: 9999;
+}
 
-    &.notification-bar--fixed {
-        overflow: hidden;
-        padding: 1px 30px;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-    }
+.closed {
+  display: none;
+}
 
-    a {
-        color: white;
-        text-decoration: underline;
-
-        &:hover,
-        &:active,
-        &:focus {
-            color: inherit !important;
-        }
-
-        &.notification-bar__close {
-            color: white;
-            font-family: 'Open Sans', sans-serif;
-            font-size: 20px;
-            font-weight: 600;
-            padding: 0 10px;
-            position: absolute;
-            right: 0;
-            text-decoration: none;
-            top: 0;
-
-            &:hover {
-                color: white;
-                text-decoration: none;
-            }
-        }
-    }
+.notification-bar .notification-bar__close {
+    color: white;
 }

--- a/site/static/css/bar.css
+++ b/site/static/css/bar.css
@@ -1,12 +1,9 @@
 .notification-bar {
     background-color: purple;
     color: white;
+    padding: 5px 15px;
     text-align: center;
     width: 100%;
-}
-
-.notification-bar a {
-    padding: 5px 32px;
 }
 
 .closed {
@@ -15,5 +12,4 @@
 
 .notification-bar .notification-bar__close {
     color: white;
-    padding: 5px 5px 5px 0;
 }

--- a/site/static/css/bar.css
+++ b/site/static/css/bar.css
@@ -1,15 +1,19 @@
 .notification-bar {
     background-color: purple;
     color: white;
-    padding: 5px 15px;
     text-align: center;
     width: 100%;
 }
 
+.notification-bar a {
+    padding: 5px 32px;
+}
+
 .closed {
-  display: none;
+    display: none;
 }
 
 .notification-bar .notification-bar__close {
     color: white;
+    padding: 5px 5px 5px 0;
 }

--- a/site/static/css/styles.css
+++ b/site/static/css/styles.css
@@ -3415,7 +3415,7 @@ table>tbody>tr:nth-of-type(odd) {
     -webkit-transform: skew(0deg, -5deg);
     transform: skew(0deg, -5deg);
     background-image: linear-gradient(-135deg, #1ba4f7 0%, #4641ff 100%);
-    height: 90%;
+    height: 100%;
     left: 0;
     position: absolute;
     top: -15%;
@@ -3445,9 +3445,11 @@ table>tbody>tr:nth-of-type(odd) {
 .homepage header {
     background: transparent;
     color: #fff;
+    /*
     left: 0;
     position: absolute;
     top: 0;
+    */
     width: 100%;
 }
 
@@ -3479,7 +3481,8 @@ table>tbody>tr:nth-of-type(odd) {
 
 .homepage__intro {
     color: #fff;
-    padding: 14em 0;
+    padding-top: 8em;
+    padding-bottom: 14em;
     position: relative;
 }
 

--- a/site/static/css/styles.css
+++ b/site/static/css/styles.css
@@ -3445,11 +3445,6 @@ table>tbody>tr:nth-of-type(odd) {
 .homepage header {
     background: transparent;
     color: #fff;
-    /*
-    left: 0;
-    position: absolute;
-    top: 0;
-    */
     width: 100%;
 }
 

--- a/site/static/js/main.js
+++ b/site/static/js/main.js
@@ -7,4 +7,8 @@ $(document).ready(function(){
         $(this).parent().next('.sub-menu').toggle();
         $(this).toggleClass('fa-plus-square-o fa-minus-square-o');
     });
+
+    $('.notification-bar__close').on('click', function(){
+       $(".notification-bar").addClass("closed");
+    });
 });


### PR DESCRIPTION
- [x] Make it closable
- [x] When at top, don't cover menus but float (stay at top of screen) on scroll

|  After |  Before |
|---|---|
| ![screenshot from 2018-11-28 16-14-45](https://user-images.githubusercontent.com/16541325/49161247-c25e4700-f328-11e8-991c-532ab8f0642e.png)  |  ![screenshot from 2018-12-04 09-15-10](https://user-images.githubusercontent.com/16541325/49428000-26f42880-f7a5-11e8-9999-7bf1b0cc1dda.png)  |


There a slight changes to the background. I'm not an CSS expert. For comparison  with a closed notification:


|  After |  Before |
|---|---|
| ![screenshot from 2018-11-28 16-11-13](https://user-images.githubusercontent.com/16541325/49161311-e3bf3300-f328-11e8-8fc3-2081d483d2de.png) | ![screenshot from 2018-11-28 16-11-18](https://user-images.githubusercontent.com/16541325/49161325-ea4daa80-f328-11e8-91cd-33ad6d968fee.png) | 

Fixes #5 