### PR TITLE
Fix typos from $(go env GOPATH)/go to $(go env GOPATH)

### DIFF
--- a/site/content/contribute/webapp/developer-setup.md
+++ b/site/content/contribute/webapp/developer-setup.md
@@ -26,7 +26,7 @@ Set up your development environment for building, running, and testing the Matte
     ```sh
     export GITHUB_USERNAME=my_username
     mkdir -p $(go env GOPATH)/src/github.com/mattermost
-    git clone https://github.com/$GITHUB_USERNAME/mattermost-webapp.git $(go env GOPATH)/go/src/mattermost/mattermost-webapp
+    git clone https://github.com/$GITHUB_USERNAME/mattermost-webapp.git $(go env GOPATH)/src/mattermost/mattermost-webapp
     ```
 
 6. Link the `client` directory in your server with the `dist` directory in your webapp:
@@ -38,6 +38,6 @@ Set up your development environment for building, running, and testing the Matte
 7. Test your environment:
 
     ```sh
-    cd $(go env GOPATH)/go/src/mattermost/mattermost-webapp
+    cd $(go env GOPATH)/src/mattermost/mattermost-webapp
     make test
     ```

--- a/site/content/contribute/webapp/developer-setup.md
+++ b/site/content/contribute/webapp/developer-setup.md
@@ -26,7 +26,7 @@ Set up your development environment for building, running, and testing the Matte
     ```sh
     export GITHUB_USERNAME=my_username
     mkdir -p $(go env GOPATH)/src/github.com/mattermost
-    git clone https://github.com/$GITHUB_USERNAME/mattermost-webapp.git $(go env GOPATH)/src/mattermost/mattermost-webapp
+    git clone https://github.com/$GITHUB_USERNAME/mattermost-webapp.git $(go env GOPATH)/src/github.com/mattermost/mattermost-webapp
     ```
 
 6. Link the `client` directory in your server with the `dist` directory in your webapp:
@@ -38,6 +38,6 @@ Set up your development environment for building, running, and testing the Matte
 7. Test your environment:
 
     ```sh
-    cd $(go env GOPATH)/src/mattermost/mattermost-webapp
+    cd $(go env GOPATH)/src/github.com/mattermost/mattermost-webapp
     make test
     ```


### PR DESCRIPTION
In Developer Setup for Web App, mattermost-webapp is installed in `$(go env GOPATH)/go/src/mattermost/`. I seem it's so strange because of the following reasons:

1. mattermost-server is installed in `$(go env GOPATH)/src/github.com/mattermost/`
1. `$(go env GOPATH)/src/github.com/mattermost` is created at before the command.
1. In Step 5, A symlink is created with `$(go env GOPATH)/src/github.com/mattermost/mattermost-webapp/dist`

`$(go env GOPATH)/go` is probably a typo for `$(go env GOPATH)`.

I've confirmed that modified commands work correctly and all tests are passed.
