### PR TITLE
Added command to avoid permission issue while running docker

### DIFF
--- a/site/content/contribute/server/developer-setup/centos.md
+++ b/site/content/contribute/server/developer-setup/centos.md
@@ -3,6 +3,7 @@
     ```sh
     curl -fsSL https://get.docker.com -o get-docker.sh
     sudo sh get-docker.sh
+    sudo usermod -aG docker $(whoami)
     docker login
     ```
 

--- a/site/content/contribute/server/developer-setup/ubuntu.md
+++ b/site/content/contribute/server/developer-setup/ubuntu.md
@@ -3,7 +3,7 @@
     ```sh
     curl -fsSL https://get.docker.com -o get-docker.sh
     sudo sh get-docker.sh
-    sudo usermod -G docker {username}
+    sudo usermod -aG docker {username}
     docker login
     ```
 

--- a/site/content/contribute/server/developer-setup/ubuntu.md
+++ b/site/content/contribute/server/developer-setup/ubuntu.md
@@ -3,7 +3,7 @@
     ```sh
     curl -fsSL https://get.docker.com -o get-docker.sh
     sudo sh get-docker.sh
-    sudo usermod -aG docker {username}
+    sudo usermod -aG docker $(whoami)
     docker login
     ```
 

--- a/site/content/contribute/server/developer-setup/ubuntu.md
+++ b/site/content/contribute/server/developer-setup/ubuntu.md
@@ -3,6 +3,7 @@
     ```sh
     curl -fsSL https://get.docker.com -o get-docker.sh
     sudo sh get-docker.sh
+    sudo usermod -G docker {username}
     docker login
     ```
 


### PR DESCRIPTION
After installing docker, sudo permission was required to run docker and hence the subsequent 'make' command was failing to run the server. By adding the user to the docker group, this can be resolved.