### PR TITLE
Update developer documentation

### DIFF
--- a/site/content/contribute/server/developer-workflow.md
+++ b/site/content/contribute/server/developer-workflow.md
@@ -74,6 +74,18 @@ After that, you can generate random data to populate the Mattermost database usi
 mattermost sampledata
 ```
 
+You can create an account using the following command:
+
+```
+mattermost user create --email user@example.com --username test1 --password mypassword
+```
+
+Optionally, you can make that account a System Admin with the following command:
+
+```
+mattermost user create --email user@example.com --username test1 --password mypassword --system_admin
+```
+
 ### Testing email notifications
 
 When Docker starts, the SMTP server is available on port 2500. Username and password are not required.


### PR DESCRIPTION
When I set up the mattermost-server/webapp repos locally, I couldn't figure out who to create a new user to log into mattermost with. Adding two commands to the developer flow on how to create a user on initial setup.