### PR TITLE
Update help wanted issue queries

### DIFF
--- a/site/content/contribute/desktop/_index.md
+++ b/site/content/contribute/desktop/_index.md
@@ -16,4 +16,4 @@ https://community.mattermost.com/core/channels/desktop-app
 
 ## Help Wanted
 
-[Find help wanted tickets here.](https://mattermost.com/pl/help-wanted-mattermost-server)
+[Find help wanted tickets here.](https://mattermost.com/pl/help-wanted-desktop)

--- a/site/content/contribute/desktop/_index.md
+++ b/site/content/contribute/desktop/_index.md
@@ -16,4 +16,4 @@ https://community.mattermost.com/core/channels/desktop-app
 
 ## Help Wanted
 
-[Find help wanted tickets here.](https://github.com/mattermost/desktop/issues?q=is%3Aopen+is%3Aissue+label%3A%22Help+Wanted%22)
+[Find help wanted tickets here.](https://mattermost.com/pl/help-wanted-mattermost-server)

--- a/site/content/contribute/getting-started/_index.md
+++ b/site/content/contribute/getting-started/_index.md
@@ -17,6 +17,6 @@ Our goal is to make your experience as great as possible. Follow these simple st
 
 {{< bignumber number="3" title="Set up your developer machine" content="Each project has its own developer setup instructions. Find them in the sidebar on the left." >}}
 
-{{< bignumber number="4" title="Select a ticket" content="All help wanted tickets are under the [server repository's GitHub issues](https://github.com/mattermost/mattermost-server/issues?q=is%3Aissue+is%3Aopen+label%3A%22Up+For+Grabs%22). Comment to let everyone know you’re working on it. If there’s no ticket for what you want to work on see [contributions without a ticket.](/contribute/getting-started/contributions-without-ticket)" >}}
+{{< bignumber number="4" title="Select a ticket" content="All help wanted tickets are under the [server repository's GitHub issues](https://mattermost.com/pl/help-wanted-mattermost-server). Comment to let everyone know you’re working on it. If there’s no ticket for what you want to work on see [contributions without a ticket.](/contribute/getting-started/contributions-without-ticket)" >}}
 
 {{< bignumber number="5" title="Start developing" content="Each project has its own developer flow for tips on working with the Mattermost codebase. When your changes are ready, run through our [checklist for pull requests](/contribute/getting-started/contribution-checklist). Note that if it’s your first contribution, there is a standard [CLA](https://www.mattermost.org/mattermost-contributor-agreement/) to sign." >}}

--- a/site/content/contribute/mobile/_index.md
+++ b/site/content/contribute/mobile/_index.md
@@ -18,4 +18,4 @@ https://community.mattermost.com/core/channels/native-mobile-apps
 
 ## Help Wanted
 
-[Find help wanted tickets here.](https://github.com/mattermost/mattermost-mobile/issues?q=is%3Aopen+is%3Aissue+label%3A%22Help+Wanted%22)
+[Find help wanted tickets here.](https://mattermost.com/pl/help-wanted-mattermost-mobile)

--- a/site/content/contribute/redux/_index.md
+++ b/site/content/contribute/redux/_index.md
@@ -16,7 +16,7 @@ https://community.mattermost.com/core/channels/redux
 
 ## Help Wanted
 
-[Find help wanted tickets here.](https://github.com/mattermost/mattermost-server/issues?q=is%3Aopen+is%3Aissue+label%3ARedux+label%3A%22Up+For+Grabs%22)
+[Find help wanted tickets here.](https://mattermost.com/pl/help-wanted-mattermost-redux)
 
 ## Background reading
 

--- a/site/content/contribute/webapp/_index.md
+++ b/site/content/contribute/webapp/_index.md
@@ -14,7 +14,7 @@ https://github.com/mattermost/mattermost-webapp
 
 ## Help Wanted
 
-[Find help wanted tickets here.](https://github.com/mattermost/mattermost-server/issues?q=is%3Aopen+is%3Aissue+label%3AReactJS+label%3A%22Up+For+Grabs%22)
+[Find help wanted tickets here.](https://mattermost.com/pl/help-wanted-mattermost-webapp)
 
 ## Folder Structure
 

--- a/site/content/contribute/webapp/end-to-end-tests.md
+++ b/site/content/contribute/webapp/end-to-end-tests.md
@@ -49,7 +49,7 @@ The folder structure is based on the [Cypress scaffold](https://docs.cypress.io/
 
 ## Interested in Contributing to E2E Testing through Help Wanted Tickets
 
-1. All help wanted tickets are under [server repository's GitHub issues](https://github.com/mattermost/mattermost-server/issues?q=is%3Aissue+is%3Aopen+label%3A%22Up+For+Grabs%22). Look for issues with `Add E2E Tests` and `Up For Grabs` labels, and comment to let everyone know you're working on it.
+1. All help wanted tickets are under [server repository's GitHub issues](https://mattermost.com/pl/help-wanted-mattermost-server). Look for issues with `Add E2E Tests` and `Up For Grabs` labels, and comment to let everyone know you're working on it.
 2. Each ticket is filled up with specific test steps and verifications that need to be accomplished as a minimum requirement.  Additional steps and assertions for robust test implementation are much welcome.
 3. Join our channel at [UI Test Automation](https://community.mattermost.com/core/channels/ui-test-automation) and talk to us as fellow contributors, and collaborate and learn with one another.
 


### PR DESCRIPTION
Update help wanted issue query to a permalink which redirects from https://mattermost.com/pl/help-wanted-mattermost-server to the appropriate query.

##### Why the change?
The GitHub help wanted issue query changed, breaking all existing links. By using a permalink, we'll only need to update the link once by fixing the redirect from https://mattermost.com/pl/help-wanted-server

##### Why this format for redirects?
This is consistent with redirects we use in the product. Moreover, by specifying the repo makes it clear which repository the link redirects to. The list of pages and their redirects are listed below

1 - https://mattermost.com/pl/help-wanted-mattermost-server
 - redirects to https://github.com/mattermost/mattermost-server/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3A%22Help+Wanted%22+label%3A%22Tech%2FGo%22

2 - https://mattermost.com/pl/help-wanted-desktop
 - redirects to https://github.com/mattermost/desktop/issues?q=is%3Aopen+is%3Aissue+label%3A%22Help+Wanted%22

3 - https://mattermost.com/pl/help-wanted-mattermost-mobile
 - redirects to https://github.com/mattermost/mattermost-server/issues?utf8=%E2%9C%93&q=label%3A%22Help+Wanted%22+label%3A%22Tech%2FReact+Native%22+is%3Aopen

4 - https://mattermost.com/pl/help-wanted-mattermost-webapp
 - redirects to https://github.com/mattermost/mattermost-server/issues?utf8=%E2%9C%93&q=label%3A%22Tech%2FReactJS%22+label%3A%22Help+Wanted%22+is%3Aopen

5 - https://mattermost.com/pl/help-wanted-mattermost-redux
 - redirects to https://github.com/mattermost/mattermost-server/issues?utf8=%E2%9C%93&q=label%3A%22Tech%2FRedux%22+label%3A%22Help+Wanted%22+is%3Aopen