### PR TITLE
fix bullet formatting on Sustained Engineering Team

### DIFF
--- a/site/content/internal/sustained-engineering.md
+++ b/site/content/internal/sustained-engineering.md
@@ -72,6 +72,7 @@ Below is how SET prioritizes what is worked on.
 ## Triage
 
 SET attends all triage meetings. During triage, SET should:
+
 * Help route tickets to the appropriate feature team
 * Assign bugs to SET when there is no clear feature team owner
 * Make sure reported bugs are in fact bugs and recommend turning non-bugs into stories or feature requests


### PR DESCRIPTION
Fix a minor rendering issue:

<img width="801" alt="image" src="https://user-images.githubusercontent.com/1023171/58199309-9bb11580-7ca6-11e9-81fc-9841f1263aa1.png">

becomes:

<img width="774" alt="image" src="https://user-images.githubusercontent.com/1023171/58199333-a1a6f680-7ca6-11e9-9bcb-fbd769b736f6.png">
