### PR TITLE
Update overview section for plugins

### DIFF
--- a/site/content/extend/plugins/overview/_index.md
+++ b/site/content/extend/plugins/overview/_index.md
@@ -5,7 +5,11 @@ subsection: Plugins (Beta)
 weight: 1
 ---
 
-Plugins are defined by a manifest file and contain at least a server or web app component, or both. The [sample plugin](https://github.com/mattermost/mattermost-plugin-sample) is a starting point and illustrates the different components of a Mattermost plugin. A more detailed example is the [demo plugin](https://github.com/mattermost/mattermost-plugin-demo), which showcases many of the features of plugins.
+Plugins are defined by a manifest file and contain at least a server or web app component, or both.
+
+The [Sample Plugin](https://github.com/mattermost/mattermost-plugin-sample) is a starting point and illustrates the different components of a Mattermost plugin.
+
+A more detailed example is the [Demo Plugin](https://github.com/mattermost/mattermost-plugin-demo), which showcases many of the features of plugins.
 
 ### Manifest
 The plugin manifest provides required metadata about the plugin, such as name and ID. It is defined in JSON or YAML. This is `plugin.json` in both the [sample](https://github.com/mattermost/mattermost-plugin-sample/blob/master/plugin.json) and [demo](https://github.com/mattermost/mattermost-plugin-demo/blob/master/plugin.json) plugins.


### PR DESCRIPTION
Links to the sample and demo plugins are already at the top of the overview section, but community is having trouble seeing/finding them.

Updated overview section to make it easier to see the references for Sample and Demo plugins. Other suggestions welcome