### PR TITLE
Bad link to contributions-without-ticket

### DIFF
--- a/site/content/contribute/getting-started/contribution-checklist.md
+++ b/site/content/contribute/getting-started/contribution-checklist.md
@@ -14,7 +14,7 @@ Follow this checklist for submitting a pull request (PR):
 1. You've signed the [Contributor License Agreement](http://www.mattermost.org/mattermost-contributor-agreement/), so you can be added to the Mattermost [Approved Contributor List](https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true).
  - If you've included your mailing address in the signed [Contributor License Agreement](https://www.mattermost.org/mattermost-contributor-agreement/), you may receive a [Limited Edition Mattermost Mug](https://forum.mattermost.org/t/limited-edition-mattermost-mugs/143) as a thank you gift after your first pull request is merged.
 2. Your ticket is a help wanted GitHub issue for one of the Mattermost project you're contributing to.
-    - If not, follow the process [here](/contribute/getting-started/contributions-without-ticket.md).
+    - If not, follow the process [here](/contribute/getting-started/contributions-without-ticket).
 3. Your code follows the [Mattermost Style Guide](http://docs.mattermost.com/developer/style-guide.html).
 4. Code thoroughly tested, including appropriate unit tests, [end-to-end tests for webapp](/contribute/webapp/end-to-end-tests/) and manual testing.
 5. If applicable, user interface strings are included in localization files:

--- a/site/content/contribute/getting-started/contribution-checklist.md
+++ b/site/content/contribute/getting-started/contribution-checklist.md
@@ -14,7 +14,7 @@ Follow this checklist for submitting a pull request (PR):
 1. You've signed the [Contributor License Agreement](http://www.mattermost.org/mattermost-contributor-agreement/), so you can be added to the Mattermost [Approved Contributor List](https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true).
  - If you've included your mailing address in the signed [Contributor License Agreement](https://www.mattermost.org/mattermost-contributor-agreement/), you may receive a [Limited Edition Mattermost Mug](https://forum.mattermost.org/t/limited-edition-mattermost-mugs/143) as a thank you gift after your first pull request is merged.
 2. Your ticket is a help wanted GitHub issue for one of the Mattermost project you're contributing to.
-    - If not, follow the process [here](/contribute/contributions-without-ticket).
+    - If not, follow the process [here](/contribute/getting-started/contributions-without-ticket).
 3. Your code follows the [Mattermost Style Guide](http://docs.mattermost.com/developer/style-guide.html).
 4. Code thoroughly tested, including appropriate unit tests, [end-to-end tests for webapp](/contribute/webapp/end-to-end-tests/) and manual testing.
 5. If applicable, user interface strings are included in localization files:

--- a/site/content/contribute/getting-started/contribution-checklist.md
+++ b/site/content/contribute/getting-started/contribution-checklist.md
@@ -14,7 +14,7 @@ Follow this checklist for submitting a pull request (PR):
 1. You've signed the [Contributor License Agreement](http://www.mattermost.org/mattermost-contributor-agreement/), so you can be added to the Mattermost [Approved Contributor List](https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true).
  - If you've included your mailing address in the signed [Contributor License Agreement](https://www.mattermost.org/mattermost-contributor-agreement/), you may receive a [Limited Edition Mattermost Mug](https://forum.mattermost.org/t/limited-edition-mattermost-mugs/143) as a thank you gift after your first pull request is merged.
 2. Your ticket is a help wanted GitHub issue for one of the Mattermost project you're contributing to.
-    - If not, follow the process [here](/contribute/getting-started/contributions-without-ticket).
+    - If not, follow the process [here](/contribute/getting-started/contributions-without-ticket.md).
 3. Your code follows the [Mattermost Style Guide](http://docs.mattermost.com/developer/style-guide.html).
 4. Code thoroughly tested, including appropriate unit tests, [end-to-end tests for webapp](/contribute/webapp/end-to-end-tests/) and manual testing.
 5. If applicable, user interface strings are included in localization files:


### PR DESCRIPTION
The link in this page https://developers.mattermost.com/contribute/getting-started/contribution-checklist/ to the contributions-without-tickets page is broken. It's missing the "getting-started" directory in the path. The link in the sidebar is correct, however.