### PR TITLE
Update references to "mattermost-plugin-sample" to be "mattermost-plugin-starter-template"

### DIFF
--- a/site/content/contribute/getting-started/contribution-checklist.md
+++ b/site/content/contribute/getting-started/contribution-checklist.md
@@ -25,7 +25,7 @@ Follow this checklist for submitting a pull request (PR):
 7. PR title begins with the JIRA or GitHub Ticket ID (e.g. `MM-394` or `GH-394`) and summary template is filled out.
 8. Once submitted, the automated build process must pass for the PR.
 9. If your PR adds or changes a RESTful API endpoint, please update the [API documentation](https://github.com/mattermost/mattermost-api-reference).
-10. If your PR adds a new plugin API method or hook, please add an example to the [Plugin Starter Template](https://github.com/mattermost/mattermost-plugin-sample).
+10. If your PR adds a new plugin API method or hook, please add an example to the [Plugin Starter Template](https://github.com/mattermost/mattermost-plugin-starter-template).
 
 That's all! If you have any feedback about this checklist, let us know in the [Contributors channel](https://community.mattermost.com/core/channels/tickets).
 

--- a/site/content/extend/plugins/_index.md
+++ b/site/content/extend/plugins/_index.md
@@ -20,7 +20,7 @@ Launch and manage server plugins as services from your Mattermost server over RP
 Extend the Mattermost REST API with custom endpoints for use by web app plugins or third-party services. Custom endpoints have access to all the features of the standard Mattermost REST API, including personal access tokens and OAuth 2.0.
 
 ### Simple Development and Installation
-Using the [server](/extend/plugins/server/hello-world) and [web app](/extend/plugins/webapp/hello-world) quick start guides, it's simple to set up a plugin development environment. You can also base your implementation off of [mattermost-plugin-sample](https://github.com/mattermost/mattermost-plugin-sample), complete with build scripts and templates. Once bundled as a gzipped tar file, upload your plugin to a Mattermost server through the [System Console](https://about.mattermost.com/default-plugin-uploads) or via the [API](https://api.mattermost.com/#tag/plugins).
+Using the [server](/extend/plugins/server/hello-world) and [web app](/extend/plugins/webapp/hello-world) quick start guides, it's simple to set up a plugin development environment. You can also base your implementation off of [mattermost-plugin-starter-template](https://github.com/mattermost/mattermost-plugin-starter-template), complete with build scripts and templates. Once bundled as a gzipped tar file, upload your plugin to a Mattermost server through the [System Console](https://about.mattermost.com/default-plugin-uploads) or via the [API](https://api.mattermost.com/#tag/plugins).
 
 ----
 Read the plugins [overview](/extend/plugins/overview) to learn more.

--- a/site/content/extend/plugins/example-plugins.md
+++ b/site/content/extend/plugins/example-plugins.md
@@ -19,7 +19,7 @@ To see a demonstration of all server-side hooks and webapp components, take a lo
 
 ## Sample Plugin
 
-To see a stripped down version of the demo plugin with just the build scripts and templates to get started, take a look at our [sample plugin](https://github.com/mattermost/mattermost-plugin-sample).
+To see a stripped down version of the demo plugin with just the build scripts and templates to get started, take a look at our [plugin starter template](https://github.com/mattermost/mattermost-plugin-starter-template).
 
 ## Zoom
 

--- a/site/content/extend/plugins/migration.md
+++ b/site/content/extend/plugins/migration.md
@@ -32,7 +32,7 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 }
 ```
 
-Writing to `Greeting` while the plugin may be concurrently reading from same could result in a corrupted read or write. The [mattermost-plugin-sample](https://github.com/mattermost/mattermost-plugin-sample) and [mattermost-plugin-demo](https://github.com/mattermost/mattermost-plugin-demo) have both been updated with more complete examples, but the general idea is to manually handle the `OnConfigurationChange` hook and synchronize access to these variables. One such way is with a [sync.RWMutex](https://golang.org/pkg/sync/#RWMutex):
+Writing to `Greeting` while the plugin may be concurrently reading from same could result in a corrupted read or write. The [mattermost-plugin-starter-template](https://github.com/mattermost/mattermost-plugin-starter-template) and [mattermost-plugin-demo](https://github.com/mattermost/mattermost-plugin-demo) have both been updated with more complete examples, but the general idea is to manually handle the `OnConfigurationChange` hook and synchronize access to these variables. One such way is with a [sync.RWMutex](https://golang.org/pkg/sync/#RWMutex):
 
 ```go
 type Plugin struct {
@@ -67,7 +67,7 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 }
 ```
 
-Unfortunately, this adds a fair bit of extra complexity. You may wish to base your updated implementation off of [mattermost-plugin-sample](https://github.com/mattermost/mattermost-plugin-sample) or [mattermost-plugin-demo](https://github.com/mattermost/mattermost-plugin-demo) to simplify your code.
+Unfortunately, this adds a fair bit of extra complexity. You may wish to base your updated implementation off of [mattermost-plugin-starter-template](https://github.com/mattermost/mattermost-plugin-starter-template) or [mattermost-plugin-demo](https://github.com/mattermost/mattermost-plugin-demo) to simplify your code.
 
 ## Migrating Plugins from Mattermost 5.1 and earlier
 

--- a/site/content/extend/plugins/overview/_index.md
+++ b/site/content/extend/plugins/overview/_index.md
@@ -7,26 +7,26 @@ weight: 1
 
 Plugins are defined by a manifest file and contain at least a server or web app component, or both.
 
-The [Sample Plugin](https://github.com/mattermost/mattermost-plugin-sample) is a starting point and illustrates the different components of a Mattermost plugin.
+The [Plugin Starter Template](https://github.com/mattermost/mattermost-plugin-starter-template) is a starting point and illustrates the different components of a Mattermost plugin.
 
 A more detailed example is the [Demo Plugin](https://github.com/mattermost/mattermost-plugin-demo), which showcases many of the features of plugins.
 
 ### Manifest
-The plugin manifest provides required metadata about the plugin, such as name and ID. It is defined in JSON or YAML. This is `plugin.json` in both the [sample](https://github.com/mattermost/mattermost-plugin-sample/blob/master/plugin.json) and [demo](https://github.com/mattermost/mattermost-plugin-demo/blob/master/plugin.json) plugins.
+The plugin manifest provides required metadata about the plugin, such as name and ID. It is defined in JSON or YAML. This is `plugin.json` in both the [sample](https://github.com/mattermost/mattermost-plugin-starter-template/blob/master/plugin.json) and [demo](https://github.com/mattermost/mattermost-plugin-demo/blob/master/plugin.json) plugins.
 
 See the [manifest reference](/extend/plugins/manifest-reference) for more information.
 
 ### Server
 The server component of a plugin is written in Go and runs as a subprocess of the Mattermost server process. The Go code extends the [MattermostPlugin](https://godoc.org/github.com/mattermost/mattermost-server/plugin#MattermostPlugin) struct that contains an [API](/extend/plugins/server/reference/#API) and allows for the implementation of [Hook](/extend/plugins/server/reference/#Hooks) methods that enable the plugin to interact with the Mattermost server.
 
-The sample plugin implements this simply in [plugin.go](https://github.com/mattermost/mattermost-plugin-sample/blob/master/server/plugin.go) and the demo plugin splits the API and hook usage throughout [multiple files](https://github.com/mattermost/mattermost-plugin-demo/tree/master/server).
+The sample plugin implements this simply in [plugin.go](https://github.com/mattermost/mattermost-plugin-starter-template/blob/master/server/plugin.go) and the demo plugin splits the API and hook usage throughout [multiple files](https://github.com/mattermost/mattermost-plugin-demo/tree/master/server).
 
 Read more about the server-side of plugins [here](/extend/plugins/server).
 
 ### Web/Desktop App
 The web app component of a plugin is written in JavaScript with [React](https://reactjs.org) and [Redux](https://redux.js.org/). The plugin's bundled JavaScript is included on the page and runs alongside the web app code as a [PluginClass](/extend/plugins/webapp/reference/#pluginclass) that has initialize and deinitialize methods available for implementation. The initialize function is passed through the [registry](/extend/plugins/webapp/reference/#registry) which allows the plugin to register React components, actions and hooks to modify and interact with the Mattermost web app.
 
-The sample plugin has a [shell of an implemented PluginClass](https://github.com/mattermost/mattermost-plugin-sample/blob/master/webapp/src/index.js), while the demo plugin [contains a more complete example](https://github.com/mattermost/mattermost-plugin-demo/blob/master/webapp/src/plugin.jsx).
+The sample plugin has a [shell of an implemented PluginClass](https://github.com/mattermost/mattermost-plugin-starter-template/blob/master/webapp/src/index.js), while the demo plugin [contains a more complete example](https://github.com/mattermost/mattermost-plugin-demo/blob/master/webapp/src/plugin.jsx).
 
 The desktop app is a shim of the web app, meaning any plugin that works in the web app will also work in the desktop app.
 

--- a/site/content/extend/plugins/server/hello-world.md
+++ b/site/content/extend/plugins/server/hello-world.md
@@ -7,7 +7,7 @@ weight: -10
 
 This tutorial will walk you through the basics of writing a Mattermost plugin with a server component.
 
-Note that the steps below are intentionally very manual to explain all of the pieces fitting together. In practice, we recommend referencing [mattermost-plugin-sample](https://github.com/mattermost/mattermost-plugin-sample) for helpful build scripts. Also, the plugin API changed in Mattermost 5.2. Consult the [migration](/extend/plugins/migration) document to upgrade older plugins.
+Note that the steps below are intentionally very manual to explain all of the pieces fitting together. In practice, we recommend referencing [mattermost-plugin-starter-template](https://github.com/mattermost/mattermost-plugin-starter-template) for helpful build scripts. Also, the plugin API changed in Mattermost 5.2. Consult the [migration](/extend/plugins/migration) document to upgrade older plugins.
 
 ## Prerequisites
 
@@ -55,7 +55,7 @@ go build -o plugin.exe plugin.go
 GOOS=linux GOARCH=amd64 go build -o plugin.exe plugin.go
 ```
 
-Also note that the ".exe" extension is required if you'd like your plugin to run on Windows, but is otherwise optional. Consider referencing [mattermost-plugin-sample](https://github.com/mattermost/mattermost-plugin-sample) for helpful build scripts.
+Also note that the ".exe" extension is required if you'd like your plugin to run on Windows, but is otherwise optional. Consider referencing [mattermost-plugin-starter-template](https://github.com/mattermost/mattermost-plugin-starter-template) for helpful build scripts.
 
 Now, we'll need to define the required manifest describing your plugin's entry point. Create a file named `plugin.json` with the following contents:
 

--- a/site/content/extend/plugins/webapp/actions.md
+++ b/site/content/extend/plugins/webapp/actions.md
@@ -11,7 +11,7 @@ Here we'll show how to use Redux actions with a plugin. To learn more about thes
 
 ## Prerequisites
 
-This guide assumes you have already set up your plugin development environment for web app plugins to match [mattermost-plugin-sample](https://github.com/mattermost/mattermost-plugin-sample). If not, follow the README instructions of that repository first, or [see the Hello, World! guide](/extend/plugins/webapp/hello-world).
+This guide assumes you have already set up your plugin development environment for web app plugins to match [mattermost-plugin-starter-template](https://github.com/mattermost/mattermost-plugin-starter-template). If not, follow the README instructions of that repository first, or [see the Hello, World! guide](/extend/plugins/webapp/hello-world).
 
 ## Import mattermost-redux
 

--- a/site/content/extend/plugins/webapp/hello-world.md
+++ b/site/content/extend/plugins/webapp/hello-world.md
@@ -7,7 +7,7 @@ weight: -10
 
 This tutorial will walk you through the basics of extending the Mattermost web app.
 
-Note that the steps below are intentionally very manual to explain all of the pieces fitting together. In practice, we recommend referencing [mattermost-plugin-sample](https://github.com/mattermost/mattermost-plugin-sample) for helpful build scripts. Also, the plugin API changed in Mattermost 5.2. Consult the [migration](/extend/plugins/migration) document to upgrade older plugins.
+Note that the steps below are intentionally very manual to explain all of the pieces fitting together. In practice, we recommend referencing [mattermost-plugin-starter-template](https://github.com/mattermost/mattermost-plugin-starter-template) for helpful build scripts. Also, the plugin API changed in Mattermost 5.2. Consult the [migration](/extend/plugins/migration) document to upgrade older plugins.
 
 ## Prerequisites
 


### PR DESCRIPTION
The `mattermost-plugin-sample` repo is being renamed to `mattermost-plugin-starter-template`. As a result, any references to the original name in documentation needs to be updated, including this repo.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-14189