### PR TITLE
MM-16557 Add homepage link to admin docs 

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -81,6 +81,12 @@ pygmentsStyle = "manni"
       name = "Blog"
       weight = 4
 
+    [[menu.postpend]]
+      url = "https://docs.mattermost.com/"
+      name = "Admin Docs"
+      weight = 5
+      
+
     # Workaround to add draft status to menu items
     [[params.navigation.drafts]]
       Contribute = false

--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -35,3 +35,29 @@
     gtag('js', new Date());
     gtag('config', 'UA-64458817-2');
 </script>
+
+<!-- Marketo Munchkin Tracking code for Marketing Team -->
+<script type="text/javascript">
+    (function() {
+    var didInit = false;
+    function initMunchkin() {
+    if(didInit === false) {
+    didInit = true;
+    Munchkin.init('161-FBE-733');
+    }
+    }
+    var s = document.createElement('script');
+    s.type = 'text/javascript';
+    s.async = true;
+    s.src = '//munchkin.marketo.net/munchkin.js';
+    s.onreadystatechange = function() {
+    if (this.readyState == 'complete' || this.readyState == 'loaded') {
+    initMunchkin();
+    }
+    };
+    s.onload = initMunchkin;
+    document.getElementsByTagName('head')[0].appendChild(s);
+    })();
+</script>
+
+


### PR DESCRIPTION
Add new homepage link to the admin docs, so developers who have setup their environments can understand how to login to Mattermost, then use it properly as an administrator.

As per JIRA https://mattermost.atlassian.net/browse/MM-16557