### PR TITLE
Remove /usr/local/go before installing over an existing version

### DIFF
--- a/site/content/contribute/server/developer-setup/centos.md
+++ b/site/content/contribute/server/developer-setup/centos.md
@@ -24,6 +24,7 @@
     ```sh
     sudo yum group install "Development Tools"
     sudo yum install -y wget libpng12
+    sudo rm -rf /usr/local/go
     wget https://storage.googleapis.com/golang/go1.12.linux-amd64.tar.gz
     sudo tar -C /usr/local -xzf go1.12.linux-amd64.tar.gz
     ```

--- a/site/content/contribute/server/developer-setup/ubuntu.md
+++ b/site/content/contribute/server/developer-setup/ubuntu.md
@@ -24,6 +24,7 @@
     ```sh
     sudo apt-get install -y build-essential
     wget https://storage.googleapis.com/golang/go1.12.linux-amd64.tar.gz
+    sudo rm -rf /usr/local/go
     sudo tar -C /usr/local -xzf go1.12.linux-amd64.tar.gz
     ```
 

--- a/site/content/contribute/server/developer-setup/windows-wsl.md
+++ b/site/content/contribute/server/developer-setup/windows-wsl.md
@@ -20,6 +20,7 @@ This is an unofficial guide. Community testing, feedback and improvements are we
 
     ```sh
     sudo apt-get install -y build-essential
+    sudo rm -rf /usr/local/go
     wget https://storage.googleapis.com/golang/go1.12.linux-amd64.tar.gz
     sudo tar -C /usr/local -xzf go1.12.linux-amd64.tar.gz
     ```


### PR DESCRIPTION
Some developers have got older versions installed already. This step helps to avoid multiple Go installations in the same directory.