### PR TITLE
Remove useless link from developers.mattermost.com

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -81,6 +81,12 @@ pygmentsStyle = "manni"
       name = "Blog"
       weight = 4
 
+    [[menu.postpend]]
+      url = "https://docs.mattermost.com/"
+      name = "Admin Docs"
+      weight = 5
+      
+
     # Workaround to add draft status to menu items
     [[params.navigation.drafts]]
       Contribute = false

--- a/site/content/internal/onboarding/new-staff-guide.md
+++ b/site/content/internal/onboarding/new-staff-guide.md
@@ -6,7 +6,6 @@ weight: 10
 ---
 
 ### Helpful links
-- https://docs.mattermost.com/guides/developer.html
 - https://docs.mattermost.com/developer/developer-flow.html
 - Security: Read through the security channel / issues spreadsheet and look at past exploits
 - Developer Reading List - top of public Developer channel

--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -35,3 +35,29 @@
     gtag('js', new Date());
     gtag('config', 'UA-64458817-2');
 </script>
+
+<!-- Marketo Munchkin Tracking code for Marketing Team -->
+<script type="text/javascript">
+    (function() {
+    var didInit = false;
+    function initMunchkin() {
+    if(didInit === false) {
+    didInit = true;
+    Munchkin.init('161-FBE-733');
+    }
+    }
+    var s = document.createElement('script');
+    s.type = 'text/javascript';
+    s.async = true;
+    s.src = '//munchkin.marketo.net/munchkin.js';
+    s.onreadystatechange = function() {
+    if (this.readyState == 'complete' || this.readyState == 'loaded') {
+    initMunchkin();
+    }
+    };
+    s.onload = initMunchkin;
+    document.getElementsByTagName('head')[0].appendChild(s);
+    })();
+</script>
+
+


### PR DESCRIPTION
I'm not sure why all three commits of mine are here in this one branch, but I will assume this will all get squashed and merged together. @amyblais - should I be doing something differently?

- Add Marketo Code to header on all pages
- Add `Admin Docs` link to navbar of site
- Remove a useless link from the onboarding page