### PR TITLE
Update example server test name and directory

### DIFF
--- a/site/content/contribute/server/developer-workflow.md
+++ b/site/content/contribute/server/developer-workflow.md
@@ -50,10 +50,10 @@ Since running every single unit test takes a lot of time while making changes, y
 go test -v -run='<test name or regex>' ./<package containing test>
 ```
 
-For example, if you wanted to run `TestPostUpdate` in `api/post_test.go`, you would run the following:
+For example, if you wanted to run `TestUpdatePost` in `app/post_test.go`, you would run the following:
 
 ```
-go test -v -run='TestPostUpdate' ./api
+go test -v -run='TestUpdatePost' ./app
 ```
 
 ### Useful mattermost commands


### PR DESCRIPTION
#### Summary
The example go test CLI command in the developer docs points to a test that does not exist in latest master.

The suggestion is to replace:

> For example, if you wanted to run **TestPostUpdate** in **api**/post_test.go, you would run the following:
> 
> go test -v -run='**TestPostUpdate**' **./api**

With

>For example, if you wanted to run **TestUpdatePost** in **app**/post_test.go, you would run the following:
>
>go test -v -run='**TestUpdatePost**' **./app**

The suggestion to use the test `TestUpdatePost` from the ./app folder, instead of the ./api4 folder, is because the ./app folder name has been static, whereas the ./api folder name has changed.