### PR TITLE
Add step to have a dedicated instance as part of community plugins

### DIFF
--- a/site/content/extend/plugins/community_process.md
+++ b/site/content/extend/plugins/community_process.md
@@ -58,7 +58,7 @@ QA pass involves getting a memeber of our QA team to take a look and verify the 
 
 Steps involved:
 - Ensure all setup documentation needed is clear and can be successfully followed 
-- Dedicated instance for a third-party service is deployed, if applicable
+- Dedicated instance or test account to access and test the third-party service, if applicable
 - Functional testing has been done to ensure the integration works as expected
 - For Plugins owned by Mattermost - Release testing is added to cover the main functionality of the plugin 
 

--- a/site/content/extend/plugins/community_process.md
+++ b/site/content/extend/plugins/community_process.md
@@ -58,6 +58,7 @@ QA pass involves getting a memeber of our QA team to take a look and verify the 
 
 Steps involved:
 - Ensure all setup documentation needed is clear and can be successfully followed 
+- Dedicated instance for a third-party service is deployed, if applicable
 - Functional testing has been done to ensure the integration works as expected
 - For Plugins owned by Mattermost - Release testing is added to cover the main functionality of the plugin 
 


### PR DESCRIPTION
Included in QA steps as it could be part of testing, but may also fall under PM or Dev ownership

Came up when Chris S tried to test Skype4Business plugin