### PR TITLE
Added engagio tracking scripts

### DIFF
--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -60,4 +60,15 @@
     })();
 </script>
 
-
+<!-- Engagio Tracking code for Marketing Team -->
+<script type="text/javascript" charset="utf-8">
+    var _eiq = _eiq || [];
+    var _engagio_settings = {
+      accountId: "cb6a404b72e9141b70d1f82abc04db92b4e56238"
+    };
+    (function() {
+      var ei = document.createElement('script'); ei.type = 'text/javascript'; ei.async = true;
+      ei.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'web-analytics.engagio.com/js/ei.js';
+      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ei, s);
+    })();
+  </script>


### PR DESCRIPTION
Another marketing request - as per MM-17287 https://mattermost.atlassian.net/browse/MM-17287

This helps our Account based sales system to track people who come to various MM sites.  It shows which companies are interested in our content.

What it does: https://docs.engagio.com/en/articles/202-web-tracking-script

> The Javascript snippet above asynchronously loads the actual Javascript that will run on your site. Our Javascript code captures high-level details about the page such as the URL and title of the web page, then sends it to the Engagio servers as a request for a pixel. It also adds a cookie to determine whether the visitor is visiting for the first time or if we've already seen this anonymous person before.
> 
> Once we get our micro payload with the page view metadata, we do a reverse IP address lookup on the client IP address that sent us that data to try and identify what account they are at via a third party, we use Kickfire's API to do this.
> 
> Once we have Kickfire's domain that is matched to that IP address, we look for accounts in your Salesforce instance with a matching domain. As of July 1st, 2019 - If multiple accounts match the domain, Engagio will associate the visits to the account with the most Contact records in Salesforce.
> 
> No information is sent back to your website from our request with the pixel, we do not provide the matched account information via our tracking script in any way. There is no other function our tracking script provides. 
> 