### PR TITLE
Bump hugo version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 go: "1.11"
 env:
-  - HUGO_VERSION="0.45.1"
+  - HUGO_VERSION="0.56.3"
 before_install:
   - mkdir bin
   - export PATH=$PATH:$PWD/bin

--- a/site/content/contribute/mobile/push-notifications/_index.md
+++ b/site/content/contribute/mobile/push-notifications/_index.md
@@ -12,5 +12,6 @@ When building a custom version of the Mattermost mobile app, you will also need 
     - [iOS](/contribute/mobile/push-notifications/ios)
 2. [Setup the Mattermost Push Notification Service](/contribute/mobile/push-notifications/service)
 
-
-{{% note "Migration" %}} As of April 10, 2018, Google has deprecated the [Google Cloud Messaging (GCM) service](https://developers.google.com/cloud-messaging/gcm). The GCM server and client APIs are deprecated and will be removed as of April 11, 2019. **If you are running the Mattermost Push Notification Service v5.4 or earlier**, you must [migrate to Firebase Cloud Messaging (FCM)](/contribute/mobile/push-notifications/migrate-gcm-fcm){{% /note %}}                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
+{{% note "Migration" %}}
+As of April 10, 2018, Google has deprecated the [Google Cloud Messaging (GCM) service](https://developers.google.com/cloud-messaging/gcm). The GCM server and client APIs are deprecated and will be removed as of April 11, 2019. **If you are running the Mattermost Push Notification Service v5.4 or earlier**, you must [migrate to Firebase Cloud Messaging (FCM)](/contribute/mobile/push-notifications/migrate-gcm-fcm)
+{{% /note %}}

--- a/site/content/contribute/mobile/push-notifications/service.md
+++ b/site/content/contribute/mobile/push-notifications/service.md
@@ -124,32 +124,29 @@ and running the service under a `mattermost-push-proxy` user account with limite
 ### Test the Mattermost Push Notification Service
 * Verify that the server is functioning normally and test the push notification using curl:
  `curl http://127.0.0.1:8066/api/v1/send_push -X POST -H "Content-Type: application/json" -d '{"type": "message", "message": "test", "badge": 1, "platform": "PLATFORM", "server_id": "MATTERMOST_DIAG_ID", "device_id": "DEVICE_ID", "channel_id": "CHANNEL_ID"}'`
-
-    * Replace `MATTERMOST_DIAG_ID` with the value found by running the SQL query:
-    ```sql
-    SELECT * FROM Systems WHERE Name = 'DiagnosticId';
-    ```
-    * Replace `DEVICE_ID` with your device ID, which can be found using (where `your_email@example.com` is the email address of the user you are logged in as):
-    ```sql
-    SELECT
-       Email, DeviceId
-    FROM
-       Sessions,
-       Users
-    WHERE
-       Sessions.UserId = Users.Id
-          AND DeviceId != ''
-          AND Email = 'your_email@example.com';
-    ```
-    * Replace `CHANNEL_ID` with the Town Square channel ID, which can be found using:
-    ```sql
-    SELECT Id FROM Channels WHERE DisplayName = 'Town Square';
-    ```
-    
-    {{% note "Migration" %}}
-    Remove the `apple:`, `apple_rn`, `android:` or `android_rn:` prefix from your device ID before replacing `DEVICE_ID`. Use that prefix as the `PLATFORM` (make sure to remove the ":").
-    {{% /note %}}
-
+  * Replace `MATTERMOST_DIAG_ID` with the value found by running the SQL query:
+  ```sql
+  SELECT * FROM Systems WHERE Name = 'DiagnosticId';
+  ```
+  * Replace `DEVICE_ID` with your device ID, which can be found using (where `your_email@example.com` is the email address of the user you are logged in as):
+  ```sql
+  SELECT
+     Email, DeviceId
+  FROM
+     Sessions,
+     Users
+  WHERE
+     Sessions.UserId = Users.Id
+        AND DeviceId != ''
+        AND Email = 'your_email@example.com';
+  ```
+  * Replace `CHANNEL_ID` with the Town Square channel ID, which can be found using:
+  ```sql
+  SELECT Id FROM Channels WHERE DisplayName = 'Town Square';
+  ```
+  {{% note "Migration" %}}
+  Remove the `apple:`, `apple_rn`, `android:` or `android_rn:` prefix from your device ID before replacing `DEVICE_ID`. Use that prefix as the `PLATFORM` (make sure to remove the ":").
+  {{% /note %}}
 * You can also verify push notifications are working by opening your Mattermost site and mentioning a user who has push notifications enabled in **Account Settings > Notifications > Mobile Push Notifications**.
 
 To view the log file, use:

--- a/site/content/internal/mobile-build-process/_index.md
+++ b/site/content/internal/mobile-build-process/_index.md
@@ -21,4 +21,6 @@ Steps to cut the mobile build:
 5. Execute the task for ``Build with Parameters`` in ``mattermost-mobile-beta-release`` and set the ``BRANCH_NAME`` to 
 ``release-X.X`` (replace the X's with the release version).
 
-{{% note "Build queue" %}}**Execute one build at a time**. Do **not** execute builds in parallel as we currently have only one build machine.{{%/note%}}
+{{% note "Build queue" %}}
+**Execute one build at a time**. Do **not** execute builds in parallel as we currently have only one build machine.
+{{%/note%}}

--- a/site/layouts/blog/single.html
+++ b/site/layouts/blog/single.html
@@ -47,7 +47,7 @@
                     <ul class="list-unstyled">
                         {{ range first 15 (where .Site.Pages ".Section" "blog" )}}
                         {{ if and (.IsPage) (ne .Title $.Title)}}
-                        <li class="blog-item__sidebar">- <a href="{{ $.Site.BaseURL }}{{.URL}}">{{ .Title }}</a></li>
+                        <li class="blog-item__sidebar">- <a href="{{ .Permalink }}">{{ .Title }}</a></li>
                         {{ end }}
                         {{ end }}
                     </ul>

--- a/site/layouts/partials/page-edit.html
+++ b/site/layouts/partials/page-edit.html
@@ -1,3 +1,5 @@
-<a href="{{.Site.Params.ghrepo}}edit/master/site/content/{{.File.Path}}" class="float-right edit-github">
+{{ if .File }}
+<a href="{{.Site.Params.ghrepo}}edit/master/site/content/{{ .File.Path }}" class="float-right edit-github">
     Edit on GitHub
 </a>
+{{ end }}

--- a/site/layouts/partials/sidebar.html
+++ b/site/layouts/partials/sidebar.html
@@ -23,7 +23,7 @@
         {{ if eq $.Title .Title }}
         <span class="item active"><i class="sub-menu__toggle fa {{$.Scratch.Get "icon"}}" aria-hidden="true" style="{{$.Scratch.Get "iconstyle"}}"></i><a class="active" href="#"> {{ .Title }}</a></span>
         {{ else }}
-        <span class="item"><i class="sub-menu__toggle fa {{$.Scratch.Get "icon"}}" aria-hidden="true" style="{{$.Scratch.Get "iconstyle"}}"></i><a href="{{ .URL }}"> {{ .Title }}</a></span>
+        <span class="item"><i class="sub-menu__toggle fa {{$.Scratch.Get "icon"}}" aria-hidden="true" style="{{$.Scratch.Get "iconstyle"}}"></i><a href="{{ .Permalink }}"> {{ .Title }}</a></span>
         {{ end }}
         {{ if $expanded }}
         <ul class="sub-menu" style="display: block">
@@ -45,9 +45,9 @@
                 {{ end }}
 
                 {{ if eq $.Title .Title }}
-                <span class="item active"><i class="sub-menu__toggle fa {{$.Scratch.Get "subicon"}}" aria-hidden="true" style="{{$.Scratch.Get "iconstyle"}}"></i><a class="active" href="{{ .URL }}"> {{ .Title }}</a></span>
+                <span class="item active"><i class="sub-menu__toggle fa {{$.Scratch.Get "subicon"}}" aria-hidden="true" style="{{$.Scratch.Get "iconstyle"}}"></i><a class="active" href="{{ .Permalink }}"> {{ .Title }}</a></span>
                 {{ else }}
-                <span class="item"><i class="sub-menu__toggle fa {{$.Scratch.Get "subicon"}}" aria-hidden="true" style="{{$.Scratch.Get "iconstyle"}}"></i><a href="{{ .URL }}"> {{ .Title }}</a></span>
+                <span class="item"><i class="sub-menu__toggle fa {{$.Scratch.Get "subicon"}}" aria-hidden="true" style="{{$.Scratch.Get "iconstyle"}}"></i><a href="{{ .Permalink }}"> {{ .Title }}</a></span>
                 {{ end }}
                 {{ if $subexpanded }}
                 <ul class="sub-menu" style="display: block">
@@ -56,18 +56,18 @@
                 {{ end }}
                 {{ range .Pages.ByWeight }}
                     {{ if eq $.Title .Title }}
-                    <a class="item active" href="{{ .URL }}">{{ .Title }}</a>
+                    <a class="item active" href="{{ .Permalink }}">{{ .Title }}</a>
                     {{ else }}
-                    <a class="item" href="{{ .URL }}">{{ .Title }}</a>
+                    <a class="item" href="{{ .Permalink }}">{{ .Title }}</a>
                     {{ end }}
                 {{ end }}
                 </ul>
             {{ end }}
             {{ range .Pages.ByWeight }}
                 {{ if and (eq $.Title .Title) (eq $.Params.subsection .Params.subsection) }}
-                <a class="item active" href="{{ .URL }}">{{ .Title }}</a>
+                <a class="item active" href="{{ .Permalink }}">{{ .Title }}</a>
                 {{ else }}
-                <a class="item" href="{{ .URL }}">{{ .Title }}</a>
+                <a class="item" href="{{ .Permalink }}">{{ .Title }}</a>
                 {{ end }}
             {{ end }}
         </ul>

--- a/site/layouts/shortcodes/note.html
+++ b/site/layouts/shortcodes/note.html
@@ -1,6 +1,3 @@
 <aside class="note">
-    <div class="note-icon">
-        {{partial "svg/exclamation.svg" (dict "size" "20px" ) }}
-    </div>
-    <div class="note-content">{{- .Inner -}}</div>
+    <div class="note-content">{{ .Inner | markdownify }}</div>
 </aside>

--- a/site/layouts/shortcodes/note.html
+++ b/site/layouts/shortcodes/note.html
@@ -1,3 +1,6 @@
 <aside class="note">
-    <div class="note-content">{{ .Inner | markdownify }}</div>
+    <div class="note-content">
+        <strong>{{ .Get 0 }}</strong><br>
+        {{ .Inner | markdownify }}
+    </div>
 </aside>

--- a/site/themes/layouts/partials/nav.html
+++ b/site/themes/layouts/partials/nav.html
@@ -11,13 +11,13 @@
                 <ul class="nav navbar-nav navbar-right">
 
                     {{ range .Site.Menus.prepend }}
-                        <li><a class="external" href="{{ .URL }}"><span>{{ .Name | markdownify }}</span></a></li>
+                        <li><a class="external" href="{{ .Permalink }}"><span>{{ .Name | markdownify }}</span></a></li>
                     {{ end }}
 
                     <li class="active"><a href="#" data-nav-section="home"><span>{{ with .Site.Params.navigation.home }}{{ . | markdownify }}{{ end }}</span></a></li>
 
                     {{ range .Site.Menus.postpend }}
-                        <li><a class="external" href="{{ .URL }}"><span>{{ .Name | markdownify }}</span></a></li>
+                        <li><a class="external" href="{{ .Permalink }}"><span>{{ .Name | markdownify }}</span></a></li>
                     {{ end }}
                 </ul>
             </div>


### PR DESCRIPTION
This PR:
- Bumps the Hugo version for the build
- Fixes problems with the `note` shortcode with Hugo >0.54
- Fixes some depreciations and warnings

Please note that the code is still compatible with older Hugo versions.