### PR TITLE
Update guidelines on E2E folder structure

### DIFF
--- a/site/content/contribute/webapp/end-to-end-tests.md
+++ b/site/content/contribute/webapp/end-to-end-tests.md
@@ -43,7 +43,7 @@ The folder structure is mostly based on the [Cypress scaffold](https://docs.cypr
     - To start writing tests,
         - simply create a new file (e.g. `login_spec.js`) within `/e2e/cypress/integration` folder and;
         - refresh tests list in the Cypress Test Runner and a new file should have appeared in the list.
-    - Subfolder naming convention depends on test grouping, which is usually based on the name of the "Sheet Tab" in the Release testing spreadsheet (e.g. `/e2e/cypress/integration/messaging/` for "Messaging" sheet tab).
+    - Subfolder naming convention depends on test grouping, which is usually based on the name of tab in the Release Testing spreadsheet (e.g. `/e2e/cypress/integration/messaging/` for "Messaging" tab).
     - Test cases that require an enterprise license should fall under `/e2e/cypress/integration/enterprise/`. This is to easily identify license requirements, both during local development and production testing for enterprise features.
 - `/e2e/cypress/plugins` or [Plugin Files](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Plugin-files)
     - A convenience mechanism that automatically include the plugins before running every single spec file.

--- a/site/content/contribute/webapp/end-to-end-tests.md
+++ b/site/content/contribute/webapp/end-to-end-tests.md
@@ -43,8 +43,8 @@ The folder structure is mostly based on the [Cypress scaffold](https://docs.cypr
     - To start writing tests,
         - simply create a new file (e.g. `login_spec.js`) within `/e2e/cypress/integration` folder and;
         - refresh tests list in the Cypress Test Runner and a new file should have appeared in the list.
-    - Subfolder naming convention depends on test grouping, which is usually based from "Sheet Tab" in the Release testing spreadsheet (e.g. `/e2e/cypress/integration/messaging/` for "Messaging" sheet tab).
-    - For test case that requires enterprise license, it should fall under `/e2e/cypress/integration/enterprise/`. This is to easily identify license requirement, both during local development and production test for enterprise features.
+    - Subfolder naming convention depends on test grouping, which is usually based on the name of the "Sheet Tab" in the Release testing spreadsheet (e.g. `/e2e/cypress/integration/messaging/` for "Messaging" sheet tab).
+    - Test cases that require an enterprise license should fall under `/e2e/cypress/integration/enterprise/`. This is to easily identify license requirements, both during local development and production testing for enterprise features.
 - `/e2e/cypress/plugins` or [Plugin Files](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Plugin-files)
     - A convenience mechanism that automatically include the plugins before running every single spec file.
 - `/e2e/cypress/support` or [Support Files](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Support-file)

--- a/site/content/contribute/webapp/end-to-end-tests.md
+++ b/site/content/contribute/webapp/end-to-end-tests.md
@@ -43,6 +43,8 @@ The folder structure is mostly based on the [Cypress scaffold](https://docs.cypr
     - To start writing tests,
         - simply create a new file (e.g. `login_spec.js`) within `/e2e/cypress/integration` folder and;
         - refresh tests list in the Cypress Test Runner and a new file should have appeared in the list.
+    - Subfolder naming convention depends on test grouping, which is usually based from "Sheet Tab" in the Release testing spreadsheet (e.g. `/e2e/cypress/integration/messaging/` for "Messaging" sheet tab).
+    - For test case that requires enterprise license, it should fall under `/e2e/cypress/integration/enterprise/`. This is to easily identify license requirement, both during local development and production test for enterprise features.
 - `/e2e/cypress/plugins` or [Plugin Files](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Plugin-files)
     - A convenience mechanism that automatically include the plugins before running every single spec file.
 - `/e2e/cypress/support` or [Support Files](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Support-file)


### PR DESCRIPTION
Add guidelines on folder structure
- naming of subfolder which is based from "Sheet tab" of release testing spreadsheet
- where to put those that requires enterprise license to run the test

![Screen Shot 2019-09-25 at 7 18 10 PM](https://user-images.githubusercontent.com/5334504/65596456-72dcbc00-dfc9-11e9-9df7-033c54c371bd.png)
