### PR TITLE
Bump hugo version to 0.58.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 go: "1.11"
 env:
-  - HUGO_VERSION="0.56.3"
+  - HUGO_VERSION="0.58.3"
 before_install:
   - mkdir bin
   - export PATH=$PATH:$PWD/bin


### PR DESCRIPTION
Bumping the hugo version to keep in in sync with the latest release. There have been problems in the past where we let the version get async to much which caused problems.