### PR TITLE
[MM-18676] Add tags to sort plugin server API methods

### DIFF
--- a/scripts/plugin-godocs.go
+++ b/scripts/plugin-godocs.go
@@ -58,11 +58,11 @@ func docHTML(text string) string {
 }
 
 func removeDuplicates(array []string) []string {
-	keys := make(map[string]struct{})
+	keys := make(map[string]bool)
 	set := []string{}
 	for _, element := range array {
-		if _, value := keys[element]; !value {
-			keys[element] = struct{}{}
+		if _, ok := keys[element]; !ok {
+			keys[element] = true
 			set = append(set, element)
 		}
 	}
@@ -72,9 +72,6 @@ func removeDuplicates(array []string) []string {
 func tags(doc string) []string {
 	tagRegexp := regexp.MustCompile(`@tag\s+(\w+)\s*`)
 	submatches := tagRegexp.FindAllStringSubmatch(doc, -1)
-	if (submatches == nil) {
-		return nil
-	}
 	tags := make([]string, len(submatches))
 	for i, submatch := range submatches {
 		tags[i] = submatch[1]

--- a/site/layouts/shortcodes/plugingodocs.html
+++ b/site/layouts/shortcodes/plugingodocs.html
@@ -57,9 +57,30 @@
 {{ end }}
 
 {{ define "InterfaceTOC" }}
+<ul>
+    {{ range .Interface.Methods }}
+        {{ if not (isset . "Tags") }}
+            <li><a href="#{{ $.Name }}.{{ .Name }}">{{ .Name }}({{ template "FieldsString" .Parameters }}) {{ template "ResultsString" .Results }}</a></li>
+        {{ end }}
+    {{ end }}
+</ul>
+{{ end }}
+
+{{ define "InterfaceTOCByTags" }}
     <ul>
-        {{ range .Interface.Methods }}
-        <li><a href="#{{ $.Name }}.{{ .Name }}">{{ .Name }}({{ template "FieldsString" .Parameters }}) {{ template "ResultsString" .Results }}</a></li>
+        {{ $interface := .Interface }}
+        {{ range .Interface.Tags }}
+            {{ $tag := . }}
+            <li>
+                {{ $tag }}
+                <ul>
+                {{ range $interface.Methods }}
+                    {{ if in .Tags $tag }}
+                        <li><a href="#{{ $.Name }}.{{ .Name }}">{{ .Name }}({{ template "FieldsString" .Parameters }}) {{ template "ResultsString" .Results }}</a></li>
+                    {{ end }}
+                {{ end }}
+                </ul>
+            </li>
         {{ end }}
     </ul>
 {{ end }}
@@ -73,7 +94,7 @@
 {{ end }}
 
 {{ define "InterfaceMethodDocs" }}
-    <h2>{{ .Name }}</h3>
+    <h2>{{ .Name }}</h2>
     {{ range .Interface.Methods }}
         <div>
             <h3 id="{{ $.Name }}.{{ .Name }}">({{ $.Name }}) {{ .Name }}</h3>
@@ -102,6 +123,7 @@
         <h2 id="API">API</h2>
         <p>{{ safeHTML $docs.API.HTML }}</p>
         {{ template "InterfaceTOC" dict "Name" "API" "Interface" $docs.API }}
+        {{ template "InterfaceTOCByTags" dict "Name" "API" "Interface" $docs.API }}
     </div>
     <div>
         <h2 id="Hooks">Hooks</h2>

--- a/site/layouts/shortcodes/plugingodocs.html
+++ b/site/layouts/shortcodes/plugingodocs.html
@@ -63,26 +63,21 @@
             <li><a href="#{{ $.Name }}.{{ .Name }}">{{ .Name }}({{ template "FieldsString" .Parameters }}) {{ template "ResultsString" .Results }}</a></li>
         {{ end }}
     {{ end }}
-</ul>
-{{ end }}
-
-{{ define "InterfaceTOCByTags" }}
-    <ul>
-        {{ $interface := .Interface }}
-        {{ range .Interface.Tags }}
-            {{ $tag := . }}
-            <li>
-                {{ $tag }}
-                <ul>
-                {{ range $interface.Methods }}
-                    {{ if in .Tags $tag }}
-                        <li><a href="#{{ $.Name }}.{{ .Name }}">{{ .Name }}({{ template "FieldsString" .Parameters }}) {{ template "ResultsString" .Results }}</a></li>
-                    {{ end }}
+    {{ $interface := .Interface }}
+    {{ range .Interface.Tags }}
+    {{ $tag := . }}
+    <li>
+        {{ $tag }}
+        <ul>
+            {{ range $interface.Methods }}
+                {{ if in .Tags $tag }}
+                    <li><a href="#{{ $.Name }}.{{ .Name }}">{{ .Name }}({{ template "FieldsString" .Parameters }}) {{ template "ResultsString" .Results }}</a></li>
                 {{ end }}
-                </ul>
-            </li>
-        {{ end }}
-    </ul>
+            {{ end }}
+        </ul>
+    </li>
+    {{ end }}
+</ul>
 {{ end }}
 
 {{ define "ExamplesTOC" }}
@@ -105,11 +100,11 @@
 {{ end }}
 
 {{ define "ExampleDocs" }}
-    <h2>Examples</h3>
+    <h2>Examples</h2>
     {{ range $name, $example := . }}
         {{ if hasPrefix $name "_" }}
             <div>
-                <h3 id="Examples.{{ $name }}">(Example) {{ substr $name 1 1 | upper }}{{ substr (strings.TrimPrefix "_" $name) 1 }}</h2>
+                <h3 id="Examples.{{ $name }}">(Example) {{ substr $name 1 1 | upper }}{{ substr (strings.TrimPrefix "_" $name) 1 }}</h3>
                 <p>{{ safeHTML $example.HTML }}</p>
                 <p>{{ highlight $example.Code "go" "" }}</p>
             </div>
@@ -123,7 +118,6 @@
         <h2 id="API">API</h2>
         <p>{{ safeHTML $docs.API.HTML }}</p>
         {{ template "InterfaceTOC" dict "Name" "API" "Interface" $docs.API }}
-        {{ template "InterfaceTOCByTags" dict "Name" "API" "Interface" $docs.API }}
     </div>
     <div>
         <h2 id="Hooks">Hooks</h2>


### PR DESCRIPTION
#### Summary
- Modify scripts/plugin-godocs.go to add tags to JSON:
  - Each "@tag" found in method comments is added to new "Tags" array attribute for each method
  - A global "Tags" attribute is also appended at same level as "Methods"
- Modify HTML layout to handle "Tags" in server API method index
  - No impact if no "Tags" attribute is found

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18676 aka https://github.com/mattermost/mattermost-server/issues/12265

#### Comments
Not so easy to do and test, as it touch several scripts that are not covered by tests. Would be glad to have your feedbacks! If we achieve something on this side, there will be another PR in `mattermost-server` to add correct tags to `api.go` methods. 
I did some choices that are not specified in ticket (or different) : 
* Replaced `@memberOf` by `@tag` which seems more consistent with feature description
* I only categorized index, because seems quite a bit messy with layout if we change the bottom part