### PR TITLE
Add 'How to update the config' to documentation

### DIFF
--- a/site/content/contribute/server/system_console.md
+++ b/site/content/contribute/server/system_console.md
@@ -1,0 +1,20 @@
+---
+title: "System Console"
+date: 2019-10-09T13:38:26-04:00
+weight: 5
+subsection: Server
+---
+
+## Adding fields to the configuration
+
+In order to add fields to the configuration, you need to modify `model/config.go` in the server by adding the desired field to one of the structs such as `ServiceSettings` and setting its default value in the corresponding `SetDefaults` method.
+
+
+### Exposing settings in the System Console
+
+To expose the newly added field in the System Console, you need to add that same setting to the `AdminDefinition` JS object in `components/admin_console/admin_definition.jsx`. This object defines most of the settings in the System Console.
+
+
+### Making settings available for non-admin users
+
+To make the newly added setting accessible to non-admin users in the apps, you'll need to add it to the `GenerateClientConfig` method in `config/client.go` in the server. Note that this always encodes the setting as a string, so anywhere that you would want to use this value in the client, you have to look for a string.


### PR DESCRIPTION
This adds steps on how to edit the config to the documentation as per request made by Mattermost user `joram`.

Issue #363 

---------------
Please let me know if this is not the best placement for this information. 