### PR TITLE
Get rid of GOPATH in the developers setup guide

### DIFF
--- a/site/content/contribute/server/developer-setup/arch.md
+++ b/site/content/contribute/server/developer-setup/arch.md
@@ -57,8 +57,7 @@
 8. Clone the Mattermost source code from your fork:
 
     ```sh
-    export GITHUB_USERNAME=my_username
-    git clone https://github.com/$GITHUB_USERNAME/mattermost-server.git
+    git clone https://github.com/YOUR_GITHUB_USERNAME/mattermost-server.git
     cd mattermost-server
     git config core.eol lf
     git config core.autocrlf input

--- a/site/content/contribute/server/developer-setup/arch.md
+++ b/site/content/contribute/server/developer-setup/arch.md
@@ -8,7 +8,7 @@
      ```
 
     **Note:** [MM-9791](https://github.com/mattermost/mattermost-server/pull/10872) introduced using [docker-compose](https://docs.docker.com/compose/) to manage containers. To preserve your data on upgrade, execute the following steps.
-    
+
     First, backup from any existing containers:
     ```sh
     mysqldump -h 127.0.0.1 --column-statistics=0 -u mmuser -p mattermost_test > mm_mysql_backup.sql
@@ -20,7 +20,7 @@
     psql -U mmuser -W -h 127.0.0.1 -f mm_postgres_backup.bak mattermost_test
     ```
     If you don't migrate your data, the new, docker-compose-managed containers will start out empty. To remove the old containers -- destroying any existing data -- use `make clean-old-docker`.
-    
+
 2. Install docker-compose
 
     ```sh
@@ -28,14 +28,14 @@
     ```
 
 
-4. Install Go:
+3. Install Go:
 
     ```sh
     sudo pacman -S base-devel
     sudo pacman -S go
     ```
 
-5. Update your shell's initialization script (e.g. `.bashrc` or `.zshrc`) and add the following:
+4. Update your shell's initialization script (e.g. `.bashrc` or `.zshrc`) and add the following:
 
     ```sh
     export GOPATH=$HOME/go
@@ -43,29 +43,32 @@
     export PATH=$PATH:/usr/local/go/bin
     ```
 
-6. Edit `/etc/security/limits.conf` as an administrator (e.g. `sudo`) and add the following lines, replacing `{username}` with your username:
+5. Edit `/etc/security/limits.conf` as an administrator (e.g. `sudo`) and add the following lines, replacing `{username}` with your username:
 
     ```sh
     {username}  soft  nofile  8096
     {username}  hard  nofile  8096
     ```
 
-7. Logout and login to effect the changes above.
+6. Logout and login to effect the changes above.
 
-8. Fork https://github.com/mattermost/mattermost-server
+7. Fork https://github.com/mattermost/mattermost-server
 
-9. Clone the Mattermost source code from your fork:
+8. Clone the Mattermost source code from your fork:
 
     ```sh
     export GITHUB_USERNAME=my_username
-    mkdir -p $(go env GOPATH)/src/github.com/mattermost
-    git clone https://github.com/$GITHUB_USERNAME/mattermost-server.git $(go env GOPATH)/src/github.com/mattermost/mattermost-server
+    git clone https://github.com/$GITHUB_USERNAME/mattermost-server.git
+    cd mattermost-server
+    git config core.eol lf
+    git config core.autocrlf input
+    git reset --hard HEAD
     ```
 
-10. Start the server and test your environment:
+9. Start the server and test your environment:
 
     ```sh
-    cd $(go env GOPATH)/src/github.com/mattermost/mattermost-server
+    cd mattermost-server
     make run-server
     curl http://localhost:8065/api/v4/system/ping
     make stop-server

--- a/site/content/contribute/server/developer-setup/arch.md
+++ b/site/content/contribute/server/developer-setup/arch.md
@@ -58,10 +58,6 @@
 
     ```sh
     git clone https://github.com/YOUR_GITHUB_USERNAME/mattermost-server.git
-    cd mattermost-server
-    git config core.eol lf
-    git config core.autocrlf input
-    git reset --hard HEAD
     ```
 
 9. Start the server and test your environment:

--- a/site/content/contribute/server/developer-setup/centos.md
+++ b/site/content/contribute/server/developer-setup/centos.md
@@ -66,10 +66,6 @@
 
     ```sh
     git clone https://github.com/YOUR_GITHUB_USERNAME/mattermost-server.git
-    cd mattermost-server
-    git config core.eol lf
-    git config core.autocrlf input
-    git reset --hard HEAD
     ```
 
 9. Start the server and test your environment:

--- a/site/content/contribute/server/developer-setup/centos.md
+++ b/site/content/contribute/server/developer-setup/centos.md
@@ -65,8 +65,7 @@
 8. Clone the Mattermost source code from your fork:
 
     ```sh
-    export GITHUB_USERNAME=my_username
-    git clone https://github.com/$GITHUB_USERNAME/mattermost-server.git
+    git clone https://github.com/YOUR_GITHUB_USERNAME/mattermost-server.git
     cd mattermost-server
     git config core.eol lf
     git config core.autocrlf input

--- a/site/content/contribute/server/developer-setup/centos.md
+++ b/site/content/contribute/server/developer-setup/centos.md
@@ -12,7 +12,7 @@
     * https://docs.docker.com/install/linux/linux-postinstall/
 
     **Note:** [MM-9791](https://github.com/mattermost/mattermost-server/pull/10872) introduced using [docker-compose](https://docs.docker.com/compose/) to manage containers. To preserve your data on upgrade, execute the following steps.
-    
+
     First, backup from any existing containers:
     ```sh
     mysqldump -h 127.0.0.1 --column-statistics=0 -u mmuser -p mattermost_test > mm_mysql_backup.sql
@@ -24,8 +24,8 @@
     psql -U mmuser -W -h 127.0.0.1 -f mm_postgres_backup.bak mattermost_test
     ```
     If you don't migrate your data, the new, docker-compose-managed containers will start out empty. To remove the old containers -- destroying any existing data -- use `make clean-old-docker`.
-    
-    
+
+
 2. Install docker-compose
 
     ```sh
@@ -33,7 +33,7 @@
     sudo chmod +x /usr/local/bin/docker-compose
     ```
 
-4. Install Go:
+3. Install Go:
 
     ```sh
     sudo yum group install "Development Tools"
@@ -43,7 +43,7 @@
     sudo tar -C /usr/local -xzf go1.12.linux-amd64.tar.gz
     ```
 
-5. Update your shell's initialization script (e.g. `.bashrc` or `.zshrc`) and add the following:
+4. Update your shell's initialization script (e.g. `.bashrc` or `.zshrc`) and add the following:
 
     ```sh
     export GOPATH=$HOME/go
@@ -51,29 +51,32 @@
     export PATH=$PATH:/usr/local/go/bin
     ```
 
-6. Edit `/etc/security/limits.conf` as an administrator (e.g. `sudo`) and add the following lines, replacing `{username}` with your username:
+5. Edit `/etc/security/limits.conf` as an administrator (e.g. `sudo`) and add the following lines, replacing `{username}` with your username:
 
     ```sh
     {username}  soft  nofile  8096
     {username}  hard  nofile  8096
     ```
 
-7. Logout and login to effect the changes above.
+6. Logout and login to effect the changes above.
 
-8. Fork https://github.com/mattermost/mattermost-server
+7. Fork https://github.com/mattermost/mattermost-server
 
-9. Clone the Mattermost source code from your fork:
+8. Clone the Mattermost source code from your fork:
 
     ```sh
     export GITHUB_USERNAME=my_username
-    mkdir -p $(go env GOPATH)/src/github.com/mattermost
-    git clone https://github.com/$GITHUB_USERNAME/mattermost-server.git $(go env GOPATH)/src/github.com/mattermost/mattermost-server
+    git clone https://github.com/$GITHUB_USERNAME/mattermost-server.git
+    cd mattermost-server
+    git config core.eol lf
+    git config core.autocrlf input
+    git reset --hard HEAD
     ```
 
-10. Start the server and test your environment:
+9. Start the server and test your environment:
 
     ```sh
-    cd $(go env GOPATH)/src/github.com/mattermost/mattermost-server
+    cd mattermost-server
     make run-server
     curl http://localhost:8065/api/v4/system/ping
     make stop-server

--- a/site/content/contribute/server/developer-setup/osx.md
+++ b/site/content/contribute/server/developer-setup/osx.md
@@ -42,10 +42,6 @@
 
     ```sh
     git clone https://github.com/YOUR_GITHUB_USERNAME/mattermost-server.git
-    cd mattermost-server
-    git config core.eol lf
-    git config core.autocrlf input
-    git reset --hard HEAD
     ```
 
 8. Start the server:

--- a/site/content/contribute/server/developer-setup/osx.md
+++ b/site/content/contribute/server/developer-setup/osx.md
@@ -1,7 +1,7 @@
 1. Install and configure Docker CE: https://docs.docker.com/docker-for-mac/.
 
     **Note:** [MM-9791](https://github.com/mattermost/mattermost-server/pull/10872) introduced using [docker-compose](https://docs.docker.com/compose/) to manage containers. To preserve your data on upgrade, execute the following steps.
-    
+
     First, backup from any existing containers:
     ```sh
     mysqldump -h 127.0.0.1 --column-statistics=0 -u mmuser -p mattermost_test > mm_mysql_backup.sql
@@ -13,8 +13,8 @@
     psql -U mmuser -W -h 127.0.0.1 -f mm_postgres_backup.bak mattermost_test
     ```
     If you don't migrate your data, the new, docker-compose-managed containers will start out empty. To remove the old containers -- destroying any existing data -- use `make clean-old-docker`.
-     
-    
+
+
 2. Download and install homebrew: https://brew.sh/.
 
 3. Install Go:
@@ -42,14 +42,17 @@
 
     ```sh
     export GITHUB_USERNAME=my_username
-    mkdir -p $(go env GOPATH)/src/github.com/mattermost
-    git clone https://github.com/$GITHUB_USERNAME/mattermost-server.git $(go env GOPATH)/src/github.com/mattermost/mattermost-server
+    git clone https://github.com/$GITHUB_USERNAME/mattermost-server.git
+    cd mattermost-server
+    git config core.eol lf
+    git config core.autocrlf input
+    git reset --hard HEAD
     ```
 
 8. Start the server:
 
     ```sh
-    cd $(go env GOPATH)/src/github.com/mattermost/mattermost-server
+    cd mattermost-server
     make run-server
     ```
 

--- a/site/content/contribute/server/developer-setup/osx.md
+++ b/site/content/contribute/server/developer-setup/osx.md
@@ -41,8 +41,7 @@
 7. Clone the Mattermost source code from your fork:
 
     ```sh
-    export GITHUB_USERNAME=my_username
-    git clone https://github.com/$GITHUB_USERNAME/mattermost-server.git
+    git clone https://github.com/YOUR_GITHUB_USERNAME/mattermost-server.git
     cd mattermost-server
     git config core.eol lf
     git config core.autocrlf input

--- a/site/content/contribute/server/developer-setup/ubuntu.md
+++ b/site/content/contribute/server/developer-setup/ubuntu.md
@@ -64,10 +64,6 @@
 
     ```sh
     git clone https://github.com/YOUR_GITHUB_USERNAME/mattermost-server.git
-    cd mattermost-server
-    git config core.eol lf
-    git config core.autocrlf input
-    git reset --hard HEAD
     ```
 
 9.  Start the server and test your environment:

--- a/site/content/contribute/server/developer-setup/ubuntu.md
+++ b/site/content/contribute/server/developer-setup/ubuntu.md
@@ -12,7 +12,7 @@
     * https://docs.docker.com/install/linux/linux-postinstall/
 
     **Note:** [MM-9791](https://github.com/mattermost/mattermost-server/pull/10872) introduced using [docker-compose](https://docs.docker.com/compose/) to manage containers. To preserve your data on upgrade, execute the following steps.
-    
+
     First, backup from any existing containers:
     ```sh
     mysqldump -h 127.0.0.1 --column-statistics=0 -u mmuser -p mattermost_test > mm_mysql_backup.sql
@@ -24,7 +24,7 @@
     psql -U mmuser -W -h 127.0.0.1 -f mm_postgres_backup.bak mattermost_test
     ```
     If you don't migrate your data, the new, docker-compose-managed containers will start out empty. To remove the old containers -- destroying any existing data -- use `make clean-old-docker`.
-    
+
 2. Install docker-compose
 
     ```sh
@@ -32,7 +32,7 @@
     sudo chmod +x /usr/local/bin/docker-compose
     ```
 
-4. Install Go:
+3. Install Go:
 
     ```sh
     sudo apt-get install -y build-essential
@@ -41,7 +41,7 @@
     sudo tar -C /usr/local -xzf go1.12.linux-amd64.tar.gz
     ```
 
-5. Update your shell's initialization script (e.g. `.bashrc` or `.zshrc`) and add the following:
+4. Update your shell's initialization script (e.g. `.bashrc` or `.zshrc`) and add the following:
 
     ```sh
     export GOPATH=$HOME/go
@@ -49,29 +49,32 @@
     export PATH=$PATH:/usr/local/go/bin
     ```
 
-6. Edit `/etc/security/limits.conf` as an administrator (e.g. `sudo`) and add the following lines, replacing `{username}` with your username:
+5. Edit `/etc/security/limits.conf` as an administrator (e.g. `sudo`) and add the following lines, replacing `{username}` with your username:
 
     ```sh
     {username}  soft  nofile  8096
     {username}  hard  nofile  8096
     ```
 
-7. Logout and login to effect the changes above.
+6. Logout and login to effect the changes above.
 
-8. Fork https://github.com/mattermost/mattermost-server
+7. Fork https://github.com/mattermost/mattermost-server
 
-9. Clone the Mattermost source code from your fork:
+8. Clone the Mattermost source code from your fork:
 
     ```sh
     export GITHUB_USERNAME=my_username
-    mkdir -p $(go env GOPATH)/src/github.com/mattermost
-    git clone https://github.com/$GITHUB_USERNAME/mattermost-server.git $(go env GOPATH)/src/github.com/mattermost/mattermost-server
+    git clone https://github.com/$GITHUB_USERNAME/mattermost-server.git
+    cd mattermost-server
+    git config core.eol lf
+    git config core.autocrlf input
+    git reset --hard HEAD
     ```
 
-10.  Start the server and test your environment:
+9.  Start the server and test your environment:
 
     ```sh
-    cd $(go env GOPATH)/src/github.com/mattermost/mattermost-server
+    cd mattermost-server
     make run-server
     curl http://localhost:8065/api/v4/system/ping
     make stop-server

--- a/site/content/contribute/server/developer-setup/ubuntu.md
+++ b/site/content/contribute/server/developer-setup/ubuntu.md
@@ -63,8 +63,7 @@
 8. Clone the Mattermost source code from your fork:
 
     ```sh
-    export GITHUB_USERNAME=my_username
-    git clone https://github.com/$GITHUB_USERNAME/mattermost-server.git
+    git clone https://github.com/YOUR_GITHUB_USERNAME/mattermost-server.git
     cd mattermost-server
     git config core.eol lf
     git config core.autocrlf input

--- a/site/content/contribute/server/developer-setup/windows-wsl.md
+++ b/site/content/contribute/server/developer-setup/windows-wsl.md
@@ -63,10 +63,6 @@ This is an unofficial guide. Community testing, feedback and improvements are we
 
     ```sh
     git clone https://github.com/YOUR_GITHUB_USERNAME/mattermost-server.git
-    cd mattermost-server
-    git config core.eol lf
-    git config core.autocrlf input
-    git reset --hard HEAD
     ```
 
 10. Start the server and test your environment:

--- a/site/content/contribute/server/developer-setup/windows-wsl.md
+++ b/site/content/contribute/server/developer-setup/windows-wsl.md
@@ -9,7 +9,7 @@ This is an unofficial guide. Community testing, feedback and improvements are we
         * You should end up with the Docker client running on Linux (WSL) sending commands to your Docker Engine daemon installed on Windows.
 
     **Note:** [MM-9791](https://github.com/mattermost/mattermost-server/pull/10872) introduced using [docker-compose](https://docs.docker.com/compose/) to manage containers. To preserve your data on upgrade, execute the following steps.
-    
+
     First, backup from any existing containers:
     ```sh
     mysqldump -h 127.0.0.1 --column-statistics=0 -u mmuser -p mattermost_test > mm_mysql_backup.sql
@@ -21,7 +21,7 @@ This is an unofficial guide. Community testing, feedback and improvements are we
     psql -U mmuser -W -h 127.0.0.1 -f mm_postgres_backup.bak mattermost_test
     ```
     If you don't migrate your data, the new, docker-compose-managed containers will start out empty. To remove the old containers -- destroying any existing data -- use `make clean-old-docker`.
-    
+
 3. Install docker-compose (using bash)
 
     ```sh
@@ -29,7 +29,7 @@ This is an unofficial guide. Community testing, feedback and improvements are we
     sudo chmod +x /usr/local/bin/docker-compose
     ```
 
-5. Install Go (using bash):
+4. Install Go (using bash):
 
     ```sh
     sudo apt-get install -y build-essential
@@ -38,11 +38,11 @@ This is an unofficial guide. Community testing, feedback and improvements are we
     sudo tar -C /usr/local -xzf go1.12.linux-amd64.tar.gz
     ```
 
-6. Set up your Go workspace:
+5. Set up your Go workspace:
     1. In PowerShell ``mkdir d:\Projects\go``
     2. In bash ``ln -s "/mnt/d/Projects/go" /home/<Linux User>/go``
 
-7. Update your shell's initialization script (e.g. `.bashrc` or `.zshrc`) and add the following:
+6. Update your shell's initialization script (e.g. `.bashrc` or `.zshrc`) and add the following:
 
     ```sh
     export GOPATH=$HOME/go
@@ -51,26 +51,29 @@ This is an unofficial guide. Community testing, feedback and improvements are we
     ulimit -n 8096
     ```
 
-8. Reload your bash configuration to effect the changes above:
+7. Reload your bash configuration to effect the changes above:
 
     ```sh
     source ~/.bashrc
     ```
 
-9. Fork Mattermost server on GitHub from https://github.com/mattermost/mattermost-server.
+8. Fork Mattermost server on GitHub from https://github.com/mattermost/mattermost-server.
 
-10. Clone the Mattermost source code from your fork:
+9. Clone the Mattermost source code from your fork:
 
     ```sh
     export GITHUB_USERNAME=my_username
-    mkdir -p $(go env GOPATH)/src/github.com/mattermost
-    git clone https://github.com/$GITHUB_USERNAME/mattermost-server.git $(go env GOPATH)/src/github.com/mattermost/mattermost-server
+    git clone https://github.com/$GITHUB_USERNAME/mattermost-server.git
+    cd mattermost-server
+    git config core.eol lf
+    git config core.autocrlf input
+    git reset --hard HEAD
     ```
 
-11. Start the server and test your environment:
+10. Start the server and test your environment:
 
     ```sh
-    cd $(go env GOPATH)/src/github.com/mattermost/mattermost-server
+    cd mattermost-server
     make run-server
     curl http://localhost:8065/api/v4/system/ping
     make stop-server

--- a/site/content/contribute/server/developer-setup/windows-wsl.md
+++ b/site/content/contribute/server/developer-setup/windows-wsl.md
@@ -62,8 +62,7 @@ This is an unofficial guide. Community testing, feedback and improvements are we
 9. Clone the Mattermost source code from your fork:
 
     ```sh
-    export GITHUB_USERNAME=my_username
-    git clone https://github.com/$GITHUB_USERNAME/mattermost-server.git
+    git clone https://github.com/YOUR_GITHUB_USERNAME/mattermost-server.git
     cd mattermost-server
     git config core.eol lf
     git config core.autocrlf input

--- a/site/content/contribute/server/developer-setup/windows.md
+++ b/site/content/contribute/server/developer-setup/windows.md
@@ -39,7 +39,7 @@
 6. Clone the Mattermost source code from your fork:
 
     ```sh
-    git clone https://github.com/{yourgithubusername}/mattermost-server.git
+    git clone https://github.com/YOUR_GITHUB_USERNAME/mattermost-server.git
     cd mattermost-server
     git config core.eol lf
     git config core.autocrlf input

--- a/site/content/contribute/server/developer-setup/windows.md
+++ b/site/content/contribute/server/developer-setup/windows.md
@@ -4,7 +4,7 @@
     * For other Windows versions, or if you prefer to use VirtualBox, use Docker Toolbox: https://docs.docker.com/toolbox/toolbox_install_windows/
 
     **Note:** [MM-9791](https://github.com/mattermost/mattermost-server/pull/10872) introduced using [docker-compose](https://docs.docker.com/compose/) to manage containers. To preserve your data on upgrade, execute the following steps.
-    
+
     First, backup from any existing containers:
     ```sh
     mysqldump -h 127.0.0.1 --column-statistics=0 -u mmuser -p mattermost_test > mm_mysql_backup.sql
@@ -16,13 +16,13 @@
     psql -U mmuser -W -h 127.0.0.1 -f mm_postgres_backup.bak mattermost_test
     ```
     If you don't migrate your data, the new, docker-compose-managed containers will start out empty. To remove the old containers -- destroying any existing data -- use `make clean-old-docker`.
-     
-    
-3. Download and install Go from https://golang.org/dl/
 
-4. Install and setup babun from http://babun.github.io/
 
-5. Setup the following environment variables (change the paths accordingly):
+2. Download and install Go from https://golang.org/dl/
+
+3. Install and setup babun from http://babun.github.io/
+
+4. Setup the following environment variables (change the paths accordingly):
 
     ```sh
     export PATH="/c/Program Files/go/bin":$PATH
@@ -34,14 +34,11 @@
     eval $(docker-machine env default) # skip this line if you are using Docker for Windows
     ```
 
-6. Fork https://github.com/mattermost/mattermost-server
+5. Fork https://github.com/mattermost/mattermost-server
 
-7. Clone the Mattermost source code from your fork:
+6. Clone the Mattermost source code from your fork:
 
     ```sh
-    cd ~/go
-    mkdir -p src/github.com/mattermost
-    cd src/github.com/mattermost
     git clone https://github.com/{yourgithubusername}/mattermost-server.git
     cd mattermost-server
     git config core.eol lf
@@ -49,10 +46,10 @@
     git reset --hard HEAD
     ```
 
-8. Start the server and test your environment:
+7. Start the server and test your environment:
 
     ```sh
-    cd $(go env GOPATH)/src/github.com/mattermost/mattermost-server
+    cd mattermost-server
     make run-server
     curl http://localhost:8065/api/v4/system/ping
     make stop-server

--- a/site/content/contribute/server/developer-setup/windows.md
+++ b/site/content/contribute/server/developer-setup/windows.md
@@ -40,10 +40,6 @@
 
     ```sh
     git clone https://github.com/YOUR_GITHUB_USERNAME/mattermost-server.git
-    cd mattermost-server
-    git config core.eol lf
-    git config core.autocrlf input
-    git reset --hard HEAD
     ```
 
 7. Start the server and test your environment:


### PR DESCRIPTION
Removing GOPATH in the developer guide based on #380. Also, I changed the numeration in some guides.

Fixes #380