### PR TITLE
add mattermost team contributors page

### DIFF
--- a/site/content/contribute/team_contributions/_index.md
+++ b/site/content/contribute/team_contributions/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Mattermost Team Contributors"
+title: "Mattermost Contributors"
 section: "contribute"
 ---
 

--- a/site/content/contribute/team_contributions/_index.md
+++ b/site/content/contribute/team_contributions/_index.md
@@ -1,0 +1,118 @@
+---
+title: "Mattermost Team Contributors"
+section: "contribute"
+---
+
+Mattermost is an open source Slack-alternative that helps teams stay in sync, with messaging and file sharing across PCs and phones, with archiving and search, and a growing community of integrations, bots and applications.
+
+
+The project is developed by a global community of contributors and is maintained and supported by a distributed company, [Mattermost Inc.](https://about.mattermost.com/company/), based in Palo Alto, California.
+
+Contributors by GitHub username and (contribution date) are alphabetically listed below by Mattermost component. The list below is updated monthly with each release:
+
+### [mattermost-server](https://github.com/mattermost/mattermost-server) and [mattermost-webapp](https://github.com/mattermost/mattermost-webapp)
+
+  - 42wim (2015.10.23), aautio (2017.02.28), abustany (2017.06.26), adamenger (2015.06.24), adzimzf (2019.01.16), Akash4927 (2018.10.03), akhilanandbv003 (2018.12.12), akihikodaki (2017.01.31), akrfjmt (2019.04.17), alanmoo (2016.02.29), alexander-akhmetov (2018.10.15), alexgaribay (2015.11.17), Alexgoodman7 (2018.02.08), alexrford (2017.07.02), ali-farooq0 (2019.03.28), alsma (2016.10.11), alxsah (2019.06.25), amogozov (2018.10.16), andreistanciu24 (2017.02.02), andresoro (2019.04.24), apaatsio (2015.09.14), apheleia (2016.05.29), apskim (2016.01.05), ArthurHlt (2016.05.16), asaadmahmood (2015.06.19), avasconcelos114 (2017.11.09), awbraunstein (2019.02.13), ayadav (2017.01.18), AymaneKhouaji (2017.01.10), Banyango (2019.06.12), BastienDurel (2015.08.26), bbodenmiller (2017.09.27), bezumkin (2018.09.21), bjoernr-de (2016.12.20), BK1603 (2019.02.14), bolariin (2019.05.27), bolecki (2016.11.15), bonespiked (2017.03.24), bradhowes (2017.03.23), brendanbowidas (2016.12.22), Brodan (2018.06.25), brunoqc (2016.04.08), carmo-evan (2019.05.29), ccbrown (2017.06.22), chahat-arora (2019.05.09), Charliekenney23 (2018.10.15), chclaus (2017.10.25), chengkun (2015.10.02), chengweiv5 (2015.06.27), cherealnice (2017.10.06), cherniavskii (2018.01.23), chetanyakan (2018.09.05), chikei (2016.09.15), chuck5 (2015.10.01), cifvts (2015.10.26), cimfalab (2018.09.17), cjbirk (2018.09.17), CometKim (2016.11.24), compaurum (2016.05.02), composednitin (2019.05.22), CoolTomatos (2018.03.06), CooperAtive (2019.04.15), cored (2018.10.17), coreyhulen (2015.06.15), courtneypattison (2019.02.19), cpanato (2016.11.14), cpfeiffer (2017.11.15), cpoile (2019.02.28), CrEaK (2017.01.19), crspeller (2015.06.15), csduarte (2016.11.05), CtrlZvi (2015.08.23), cyrilterets (2016.04.29), czertbytes (2018.10.15), d28park (2019.03.20), daizenberg (2016.02.25), dak425 (2019.06.10), danmaas (2018.09.24), davidlu1997 (2016.05.02), dchukmasov (2019.03.06), deanwhillier (2018.10.22), debanshuk (2016.12.14), deveshjadon98 (2017.11.10), digitaltoad (2016.10.31), dmitrysamuylovpharo (2018.08.29), doh5 (2017.03.29), dom3k (2019.01.30), doosp (2015.08.27, dos1701 (2018.10.08), drbaker (2015.10.01), driou (2015.09.22), dv29 (2019.01.31), ejachang (2019.02.21), ejm2172 (2016.01.04), enahum (2016.01.16), erikgui (2017.01.13), erikthered (2015.12.11), esethna (2015.09.17), evan-a-a (2019.05.02), evelikov (2018.06.28), faebser (2015.07.07), farhadab (2019.05.24), favadi (2017.02.02), feliciousx (2016.03.15), firstrow (2015.06.24), florianorben (2015.10.11), fraziern (2016.11.17), ftKnox (2017.06.22), FurmanovD (2018.09.17), gabel (2015.11.05), gabrieljackson (2019.01.29), GianOrtiz (2019.05.30), gig177 (2017.02.01), giorgosdi (2019.05.17), girishso (2015.10.18), GitHubJasper (2018.03.06), gnufede (2018.03.01), goku321 (2019.06.26), goofy-bz (2016.05.12), gramakri (2016.01.12), grundleborg (2016.09.30), gstraube (2017.04.17), GuillaumeAmat (2016.02.25), gupsho (2018.10.03), guydemi (2018.04.12), gvengel (2018.08.28), h2oloopan (2017.11.07), haikoschol (2015.06.24), Hanzei (2018.08.18), happygaijin (2019.04.05), harshavardhana (2015.10.26), harshilsharma63 (2018.09.26), hauschke (2016.04.21), herooftimeandspace (2018.07.24), hjf288 (2015.12.23), hmhealey (2015.07.03), Hobby-Student (2019.03.23), HugoGiraudel (2016.08.12), hvnsweeting (2015.12.25), Hyeongmin-Kwon (2017.11.02), Inconnu08 (2019.06.10), insin (2016.05.09), iomodo (2019.05.14), IshankGulati (2019.05.26), it33 (2015.06.15), ivanaairenee (2019.05.15), j8r (2019.03.27), jasimmons (2018.10.22), jasonblais (2015.08.27), JayaKrishnaNamburu (2018.10.15), jazzzz (2017.01.13), jdhoek (2015.11.10), jedisct1 (2015.06.24), JeffSchering (2017.03.02),  jerryfireman (2019.05.17), jesperhansen17 (2019.05.29), jespino (2017.09.14), JessBot (2015.09.08), jfrerich (2019.02.28), jkl5616 (2019.05.27), jkurian (2018.06.29), jlevesy (2018.10.15), joannekoong (2017.02.20), johnbellone (2019.04.30), johncoleman83 (2017.10.20), jonany (2019.06.26), jonathanwiesel (2015.11.20), joonsun-baek (2016.08.22), jostyee (2017.02.17), jurgenhaas (2017.01.20), justinwyer (2017.04.24), justyns (2015.09.29), jvasallo (2015.10.16), JVasky (2019.04.09), jwilander (2015.06.15), kaakaa (2016.09.16), kelvintyb (2019.03.21), kemenaran (2018.02.02), KenmyZhang (2017.08.09), kennethjeremyau (2018.06.29), kernicPanel (2015.10.31), KerryAlsace (2018.11.02), kevinetienne (2019.06.26), kevynb (2016.06.10), kh0r (2015.12.09), khawerrind (2016.12.22), khoa-le (2016.02.02), kim95175 (2019.06.25), KishoreFartiyal (2017.11.09), kkamdooong (2017.06.29), kkirsche (2019.05.07), klingtnet (2018.10.03), knrt10 (2018.10.31), kongr45gpen (2018.09.11), kosgrz (2018.12.10), koukouloforos (2019.02.23), koxen (2018.02.20), krjn (2019.06.19), kulak-at (2017.05.09), LAndreas (2015.09.07), lassimus (2019.06.25), laur89 (2017.02.17), layzerar (2015.10.15), leblanc-simon (2018.03.01), letsila (2017.10.10), lfbrock (2015.07.30), lindalumitchell (2017.03.07), lindy65 (2015.08.27), lmikaellukerad (2018.03.06), loafoe (2016.01.19), lologarithm (2018.10.04), longsleep (2017.10.06), lurcio (2019.06.02), m3phistopheles (2019.03.14), manland (2019.02.06), manusajith (2015.09.03), MartB (2019.03.01), marianunez (2019.05.15), maruTA-bis5 (2016.05.07), matshch (2019.05.09), mcmillhj (2015.10.21), MirlanMaksv (2019.02.06), MerlinDMC (2018.08.09), mfpiccolo (2016.11.04), mgdelacroix (2019.01.28), michaelkochub (2018.08.30), mickmister (2018.11.08), mikaoelitiana (2017.01.13), mikelinden1 (2017.12.01), mikroskeem (2018.09.27), mjthomp95 (2019.06.17), mkraft (2017.11.07), mishimi (2015.08.31), mogul (2017.11.24), mojicaj (2018.10.13), moonmeister (2017.06.29), morenoh149 (2017.03.01), mounicapaladugu (2019.06.06), mpoornima (2017.02.26), mstoli (2019.04.26), mukulrawat1986 (2018.10.13), MusikPolice (2017.07.24), nafisfaysal (2019.06.28), nickago (2015.06.28), nlowe (2019.01.24), npcode (2015.11.23), odontomachus (2018.05.07), oliverJurgen (2019.03.14), olivierperes (2016.04.20), optimistiks (2015.10.12), pan-feng (2017.02.14), paranbaram (2016.08.22), patniharshit (2018.11.26), patterns (2019.06.28), pawelad (2016.01.18), peasead (2016.03.10), pepf (2016.11.17), philippe-granet (2018.03.12), phrix32 (2016.08.17), pieterlexis (2017.06.29), pietroglyph (2018.07.05), piperRyan (2019.06.06), pjgrizel (2016.03.24), Ppjet6 (2017.07.31), pradeepmurugesan (2018.07.04), prapti (2019.04.25), prixone (2017.03.30), pruthvip (2017.08.21), pstonier (2015.09.25), qichengzx (2018.03.19), QuantumKing (2017.11.14), RajatVaryani (2019.06.20), ralder (2015.06.26), raphael0202 (2016.11.14), reflog (2019.03.27), rgarmsen2295 (2015.06.15), rickbatka (2017.10.17), rodrigocorsi2 (2016.02.09), rompic (2015.11.10), Rudloff (2016.09.13), ruzette (2017.02.05), rvillablanca (2019.05.30), R-Wang97 (2016.08.19), rwillmer (2016.11.01), ryantm (2017.10.10), ryoon (2016.03.24), s4kh (2018.10.21), samogot (2016.04.28), sandlis (2018.11.19), santos22 (2017.10.27), sapnasivakumar (2019.01.14), saturninoabril (2017.01.23), ScriptAutomate (2016.06.01), scottleedavis (2018.11.15), senk (2017.02.07), SergeyShpak (2018.10.23), sexybern (2015.10.05), SezalAgrawal (2019.06.27), Sheshagiri (2019.01.15), shieldsjared (2016.08.22), simon0191 (2017.04.17), S4KH (2016.10.21), sjmog (2015.09.23), sonasingh46 (2018.10.05), srkgupta (2019.06.26), stasvovk (2015.10.12), streamer45 (2019.06.26), steevsachs (2019.06.27), stupied4ever (2016.03.22), sudheerDev (2017.08.21), tamtamchik (2015.11.26), tarikeshaq (2019.06.23), tauu (2019.02.05), tbalthazarte (2015.05.17), tengis617 (2019.04.23), tkbky (2017.10.26), tehraven (2016.06.01),  theblueskies (2018.07.18), thekiiingbob (2019.03.07), therealpuneeth20 (2019.04.25), ThiefMaster (2018.06.19), thiyagaraj (2016.06.15), thomas9987 (2015.10.01), thomchop (2016.10.26), timlyo (2016.02.19), tjuerge (2017.05.31), tmuwandi (2015.10.01), tomasmik (2019.06.08), tomitm (2015.10.06), tomocy (2019.01.12), toyorg (2015.10.28), trozz (2015.09.12), Tsynapse (2015.11.06), tylarb (2019.04.22), tyvsmith (2018.10.25), usmanarif (2016.05.03), uturkdogan (2018.05.15), vaithak (2018.11.05), VeraLyu (2017.03.15), vinnymac (2015.11.01), viot (2015.10.02), vladikoff (2015.11.20), VolatianaYuliana (2019.05.07), vordimous (2018.02.07), Vorlif (2018.03.13), VPashkov (2018.10.24), waseem18 (2018.10.03), willdot (2019.06.06), willstacey (2015.08.27), Willyfrog (2019.06.15), wget (2016.10.17), Whiteaj36 (2017.08.03), Wipeout55 (2019.05.20), XinyueWang94 (2018.03.06), yeoji (2017.10.16), yth0625 (2017.11.07), yumenohosi (2016.05.04), yuvipanda (2015.11.01), Zackify (2015.08.29), Zaicon (2017.02.20), Zapix (2017.10.05), zeroimpl (2018.11.08), zetaab (2018.09.10), ZJvandeWeg (2017.01.09), zkry (2019.06.12)
+
+### [docs](https://github.com/mattermost/docs)
+
+  - 7-plus-t (2019.03.04), aaronrothschild (2019.06.21), acgustafson (2017.06.22), ajerezr (2016.05.08), alerque (2018.01.24), amaddio (2019.03.06), amyblais (2017.06.26), andrewbanchich (2018.12.20), apheleia (2016.04.23), asaadmahmood (2015.06.19), aureliojargas (2016.12.2), axilleas (2016.11.21), Balasankar C (2017.08.23), balcsida (2018.09.23), bcalik (2019.03.23), billybrown1 (2018.02.20), bkmgit (2017.07.16), burguyd (2018.07.10), ccpaging (2018.09.19), chengweiv5 (2016.02.22), chikei (2016.10.14), cjohannsen81 (2018.03.10), comharris (2017.10.12), CoolMoeDee (2018.03.16), coreyhulen (2015.11.19), cpanato (2016.11.22), crspeller (2016.03.15), dannymohammad (2019.01.02), darkman (2018.01.08), davidlu1997 (2016.05.10), DSchalla (2018.04.10), dustinkirkland (2019.05.2), elyscape (2019.06.07), enahum (2016.05.04), esethna (2016.01.13), falcon78921 (2018.07.11), fdebrabander (2018.07.30), fermulator (2018.01.10), fjarlq (2017.04.18), florianeichin (2018.10.17), Fonata (2016.06.07), gabx (2016.10.15), gmorel (2016.10.26), georgewitteman (2019.06.09), greensteve (2018.06.22), grundleborg (2016.08.29), hannapark84 (2016.05.11), haraldkubota (2018.05.07), hmhealey (2016.05.09), icelander (2018.01.24), iri-dw (2018.04.09), it33 (2016.01.13), ivernus (2017.04.22), jasonblais (2016.05.23), jdillard (2019.02.06), JeffSchering (2016.09.16), Jessica-c53 (2018.07.14), jk2K (2019.03.13), joewaitye (2019.06.04), johnthompson365 (2018.12.20), jostyee (2017.02.17), JtheBAB (2018.10.31), JustinReynolds-MM (2018.07.26), justinwyer (2017.04.24), jwilander (2016.02.16), kaakaa (2016.09.06), kjkeane (2017.05.16), knechtionscoding (2018.01.09), kscheel (2019.02.15), kunthar (2016.09.20), laginha87 (2018.01.29), lfbrock (2016.01.14), lindy65 (2015.08.27), Mario-Hofstaetter (2019.04.14), mattzamudio (2018.08.24), megos (2017.06.28), Merlin2001 (2018.04.10), michaelgamble (2018.06.05), mkhsueh (2016.05.27), nils-schween (2019.06.17), nils-werner (2016.12.15), npode (2016.05.25), okin (2016.11.21), onnadi-work (2019.02.27), pjgrizel (2016.03.25), pravan (2019.05.29), quentinus95 (2016.11.26), qyra (2016.11.23), raelga (2016.03.07), reach3r (2016.10.18), Rohlik (2017.03.20), Roy-Orbison (2018.02.18), rqtaylor (2018.03.02), Rudloff (2016.09.13), rwillmer (2016.10.26), SaashaJoshi (2018.10.09), sadohert (2019.01.20), schemacs (2016.04.20), seikichi (2016.02.23), senk (2017.02.07), Sharuru (2018.09.07),  staabm (2019.02.20), StraylightSky (2016.10.06), svelle (2018.03.20), tapaswenipathak (2019.05.14), tejasbubane (2016.12.17), tethik (2016.12.13), thawn (2018.09.04), Theaxiom (2019.06.18), timconner (2018.03.18), tolidano (2017.11.01), tomo667a (2018.04.02), torgeirl (2018.02.21), Tristramg (2018.02.05), tuxfamily (2018.11.06), TwizzyDizzy (2016.05.27), uhlhosting (2018.07.19), utaani (2019.06.10), wget (2016.09.12), wiersgallak (2018.05.31), wyleung (2016.02.12), yangchen1 (2016.06.14), Zhouzi(2016.10.09), ZJvandeWeg (2016.12.09)
+
+### [mattermost-api-reference](https://github.com/mattermost/mattermost-api-reference)
+
+  - 94117nl (2017.05.06), atpons (2017.09.20), CometKim (2016.11.16), coreyhulen (2016.09.16), cpanato (2016.11.21), crspeller (2016.09.16), dagit (2017.04.30), debanshuk (2016.12.14), Dhiver (2018.05.07), enahum (2016.10.25), grundleborg (2016.12.22), hmhealey (2016.09.16), jfcastroluis (2019.02.01), jordanbuchman (2018.05.02), jwilander (2016.09.27), MartinDelille (2016.11.10), n7st (2018.09.28), nashik (2019.01.02), ruzette (2017.02.05), saturninoabril (2017.02.17), senk (2017.02.15), thePanz (2017.06.12), trarbr (2016.12.31), Vaelor (2017.06.23), z4cco (2019.04.30), Zaicon (2017.02.20), ZJvandeWeg (2016.12.31)
+
+
+### [ios](https://github.com/mattermost/ios)
+
+  - coreyhulen (2015.12.02), it33 (2015.12.09), lfbrock (2015.12.14), PrestonL (2017.04.13), thomchop (2016.27.10)
+
+### [android](https://github.com/mattermost/android)
+
+  - arusahni (2016.03.17), cifvts (2016.03.03), coreyhulen (2016.02.24), davidlu1997 (2016.05.09), der-test (2017.05.08), dmeza (2016.10.15), it33 (2016.02.25), lfbrock (2016.06.10), lindy65 (2016.03.17), mattchue (2016.09.15), nineinchnick (2016.05.18), ptersilie (2016.03.16), SlavikCA (2016.03.07)
+
+### [desktop](https://github.com/mattermost/desktop)
+
+  - alerque (2016.01.23), asaadmahmood (2015.06.19), aswathkk (2019.02.11), Autre31415 (2018.04.25), CarmDam (2016.05.31), dkadioglu (2018.05.24), it33 (2015.12.28), itsmartin (2016.09.29), j1mc (2018.06.04), jasonblais (2015.08.27), jcomack (2016.10.01), jeremycook (2016.04.20), jgis (2016.08.16), jnugh (2016.05.07), kethinov (2018.04.17), lip-d (2018.02.17), magicmonty (2016.07.03), MetalCar (2016.05.25), mgielda (2016.03.29), mid0111 (2016.01.18), mikenicholls (2019.05.11), pascalw (2016.02.15), Razzeee (2015.05.13), rodcorsi (2018.07.30), scherno2 (2018.07.11), St-Ex (2016.08.24), thedingwing (2019.02.16), torlenor (2018.10.06), yuya-oc (2016.03.09)
+
+### [mattermost-docker](https://github.com/mattermost/mattermost-docker)
+
+  - 5ak3t (2016.10.15), andrey9kin (2016.12.20), andruwa13  (2017.11.11), antoineHC (2018.04.15), carlosasj (2017.05.16), cobenash (2018.10.29), compilenix (2018.04.10), cpanato (2018.02.18), darkrasid (2017.02.23), dcherniv (2018.08.27), Em-AK (2016.02.17), esethna (2017.04.19), FingerLiu (2017.05.24), fmaker (2016.01.05), gy741 (2018.10.27), it33 (2016.03.20), jminardi (2017.07.19), jnbt (2017.07.11),  lasley (2018.01.05), localsnet (2017.09.20), mkdbns (2017.06.02), muffl0n (2017.11.26), nikosch86 (2017.02.23), npcode (2015.11.26), Ovski4 (2019.01.29), pdemagny (2017.09.25), pichouk (2017.04.17), pierreozoux (2016.06.09), pkuhner (2018.09.19), redg3ar (2019.05.15), rothgar (2016.09.18), Schrooms (2018.12.04), seansackowitz (2018.07.16), sebgl (2017.10.20), tivvit (2017.09.20), ulm0 (2018.01.22), wildloop (2018.06.12), xcompass (2016.04.16)
+
+### [mattermost-docker-preview](https://github.com/mattermost/mattermost-docker-preview)
+
+  - cpanato (2017.01.09), crspeller (2016.05.31), hyeseongkim (2016.11.16), it33 (2016.06.01), jasonblais (2016.11.16), joelnb (2016.06.19)
+
+### [mattermost-mobile](https://github.com/mattermost/mattermost-mobile)
+
+  - alanpog (2018.07.04), asaadmahmood (2015.06.19), bradjcoughlin (2018.12.17), chumbalum (2018.03.06), cpanato (2017.04.27), csduarte (2016.12.22), dmamills (2018.01.28), dmeza (2016.10.19), enahum (2016.01.16), gajananpp (2018.03.14), gelim (2017.10.23), glebtv (2019.06.15), hmhealey (2016.10.12), it33 (2016.10.19), ja11sop (2018.12.05), jasonblais (2016.10.12), JeffSchering (2017.03.30), kingisaac95 (2019.04.02), kmandagie (2019.04.26), lfbrock (2016.01.14), mfpiccolo (2016.10.14), MParvin (2019.04.30), mzaks (2019.06.28), ninanung (2019.04.16), omar-dev (2017.06.22), onepict (2017.08.29), pesintta (2019.03.22), PeterDaveHello (2019.04.23), phuihock (2018.01.24), powhu (2018.10.10), renatopeterman (2019.06.15), rthill (2017.05.17), RyPoints (2019.04.25), saturninoabril (2017.03.13), sergeyzhukov (2019.05.08), sjstyle (2018.08.15), tekminewe (2019.06.18), thomchop (2016.10.12), uusijani (2018.07.16)
+
+### [mattermost-mattermod](https://github.com/mattermost/mattermost-mattermod)
+
+  - fcorrea (2019.02.20)
+
+### [mattermost-react-window](https://github.com/mattermost/react-window)
+
+  - bvaughn (2019.03.22)
+
+### [mattermost-bot-sample-golang](https://github.com/mattermost/mattermost-bot-sample-golang)
+
+  - coreyhulen (2016.07.14), fkr (2017.07.23), hmhealey (2016.11.07), it33 (2015.06.15), jasonblais (2016.7.26), pneisen (2016.11.05)
+
+### [mattermost-load-test](https://github.com/mattermost/mattermost-load-test)
+
+  - achepiece(2016.11.13), athingisathing (2016.10.06), coreyhulen (2016.10.05), crspeller (2016.10.04), csduarte (2016.09.30), it33 (2016.09.30), enahum (2016.09.30), jasonblais (2016.10.14), usmanarif (2016.11.13)
+
+### [mattermost-selenium](https://github.com/mattermost/mattermost-selenium)
+
+  - coreyhulen (2016.10.05), cpanato (2017.02.10), doh5 (2017.04.26), DHaussermann (2018.07.25), esethna (2016.01.13), lindalumitchell (2017.02.24), lindy65 (2018.08.21)
+
+### [mattermost-push-proxy](https://github.com/mattermost/mattermost-push-proxy)
+
+  - coreyhulen (2016.10.05), it33 (2015.06.15), jostyee (2017.02.17), michaeltaylor-kerauno (2018.04.13)
+
+### [mattermost-log4go](https://github.com/mattermost/log4go)
+
+  - coreyhulen (2016.10.05)
+
+### [mattermost-marked](https://github.com/mattermost/marked)
+
+  - hmhealey (2016.11.07)
+
+### [mattermost-redux](https://github.com/mattermost/mattermost-redux)
+
+  - aditya-konarde (2017.08.18), amorriscode (2018.10.05), brettmc (2017.08.18), chrux (2018.11.08), cpanato (2017.05.22), enahum (2017.03.16), gulhe (2019.03.19), hmhealey (2017.03.16), Hunga1 (2018.02.22), jarredwitt (2017.03.21),  jwilander (2017.03.16), kevin3274 (2017.08.15),  MattMattV (2018.10.17), migbot (2018.12.19), Robbe7730 (2019.02.06), xuxip (2018.01.24)
+
+### [mattermost-gcm](https://github.com/mattermost/gcm)
+
+  - coreyhulen (2017.04.27), csduarte (2017.04.27)
+
+### [mattermost-kubernetes](https://github.com/mattermost/mattermost-kubernetes)
+
+  - Brunzer (2018.01.30), coreyhulen (2017.03.23), cpanato (2017.11.24), daanlevi (2018.04.16), escardin (2017.08.11), stylianosrigas (2019.03.01)
+
+### [mattermost-build](https://github.com/mattermost/mattermost-build)
+
+  - mthornba (2017.10.29)
+
+### [mattermost-developer-documentation](https://github.com/mattermost/mattermost-developer-documentation)
+
+  - bd12 (2018.11.06), checkaayush (2019.03.21), cpanato (2018.06.05), ewwollesen (2019.06.14), Hanzei (2018.01.24), henrymori (2019.05.21), jasonblais (2018.05.11), johnsenner (2019.03.01), jwilander (2017.11.17), nadaa (2019.03.15), sanojsubran (2019.02.21), yakimant (2018.12.09)
+
+### [mattermost-handbook](https://github.com/mattermost/mattermost-handbook)
+
+  - ljmccaff (2019.04.17), mollyyoung (2019.01.08)
+
+### [mattermost-plugin-github](https://github.com/mattermost/mattermost-plugin-github)
+
+  - benschuster788 (2019.03.01), ivenk (2019.06.14), moksahero (2019.06.18), wbernest (2019.03.11)
+
+### [mattermost-plugin-gitlab](https://github.com/mattermost/mattermost-plugin-gitlab)
+
+  - jsmestad (2019.06.14)
+
+### [mattermost-helm](https://github.com/mattermost/mattermost-helm)
+
+  - kincl (2019.06.26), sebastien-prudhomme (2019.05.15)
+
+If you spot an error or omission in the above lists, please mail feedback@mattermost.com so we can correct the issue.


### PR DESCRIPTION
Adding the Team page (migration from here: https://www.mattermost.org/team/)

The idea is to remove that server soon, so migrate pages that are useful for community

adding @lindy65 since her update this page :)