### PR TITLE
document how to shut down and clean up docker containers

### DIFF
--- a/site/content/contribute/server/developer-setup/arch.md
+++ b/site/content/contribute/server/developer-setup/arch.md
@@ -75,3 +75,9 @@
     ```
 
     **Note:** Browsing directly to http://localhost:8065/ will display a `404 Not Found` until the web app is configured. See [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for additional setup.
+
+    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop and clean up running docker containers:
+
+    ```sh
+    make stop-docker
+    ```

--- a/site/content/contribute/server/developer-setup/arch.md
+++ b/site/content/contribute/server/developer-setup/arch.md
@@ -76,7 +76,7 @@
 
     **Note:** Browsing directly to http://localhost:8065/ will display a `404 Not Found` until the web app is configured. See [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for additional setup.
 
-    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop and clean up running docker containers:
+    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop the running docker containers:
 
     ```sh
     make stop-docker

--- a/site/content/contribute/server/developer-setup/centos.md
+++ b/site/content/contribute/server/developer-setup/centos.md
@@ -83,3 +83,9 @@
     ```
 
     **Note:** Browsing directly to http://localhost:8065/ will display a `404 Not Found` until the web app is configured. See [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for additional setup.
+
+    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop and clean up running docker containers:
+
+    ```sh
+    make stop-docker
+    ```

--- a/site/content/contribute/server/developer-setup/centos.md
+++ b/site/content/contribute/server/developer-setup/centos.md
@@ -84,7 +84,7 @@
 
     **Note:** Browsing directly to http://localhost:8065/ will display a `404 Not Found` until the web app is configured. See [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for additional setup.
 
-    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop and clean up running docker containers:
+    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop the running docker containers:
 
     ```sh
     make stop-docker

--- a/site/content/contribute/server/developer-setup/osx.md
+++ b/site/content/contribute/server/developer-setup/osx.md
@@ -67,7 +67,7 @@
 
     **Note:** Browsing directly to http://localhost:8065/ will display a `404 Not Found` until the web app is configured. See [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for additional setup.
 
-    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop and clean up running docker containers:
+    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop the running docker containers:
 
     ```sh
     make stop-docker

--- a/site/content/contribute/server/developer-setup/osx.md
+++ b/site/content/contribute/server/developer-setup/osx.md
@@ -66,3 +66,9 @@
     ```
 
     **Note:** Browsing directly to http://localhost:8065/ will display a `404 Not Found` until the web app is configured. See [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for additional setup.
+
+    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop and clean up running docker containers:
+
+    ```sh
+    make stop-docker
+    ```

--- a/site/content/contribute/server/developer-setup/ubuntu.md
+++ b/site/content/contribute/server/developer-setup/ubuntu.md
@@ -81,3 +81,9 @@
     ```
 
     **Note:** Browsing directly to http://localhost:8065/ will display a `404 Not Found` until the web app is configured. See [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for additional setup.
+
+    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop and clean up running docker containers:
+
+    ```sh
+    make stop-docker
+    ```

--- a/site/content/contribute/server/developer-setup/ubuntu.md
+++ b/site/content/contribute/server/developer-setup/ubuntu.md
@@ -82,7 +82,7 @@
 
     **Note:** Browsing directly to http://localhost:8065/ will display a `404 Not Found` until the web app is configured. See [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for additional setup.
 
-    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop and clean up running docker containers:
+    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop the running docker containers:
 
     ```sh
     make stop-docker

--- a/site/content/contribute/server/developer-setup/windows-wsl.md
+++ b/site/content/contribute/server/developer-setup/windows-wsl.md
@@ -78,6 +78,12 @@ This is an unofficial guide. Community testing, feedback and improvements are we
 
     **Note:** Browsing directly to http://localhost:8065/ will display a `404 Not Found` until the web app is configured. See [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for additional setup.
 
+    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop and clean up running docker containers:
+
+    ```sh
+    make stop-docker
+    ```
+
 ### Troubleshooting:
 1. If you see an error like `the input device is not a TTY.  If you are using mintty, try prefixing the command with 'winpty'`.  Reinstall git for windows and make sure you choose `Use Windows' default console window` instead of `Use MinTTY`
 2. The LDAP docker container is sometimes slow to start. If you see the following message, either increase the wait time in the make file or run `make run` twice in a row.

--- a/site/content/contribute/server/developer-setup/windows-wsl.md
+++ b/site/content/contribute/server/developer-setup/windows-wsl.md
@@ -78,7 +78,7 @@ This is an unofficial guide. Community testing, feedback and improvements are we
 
     **Note:** Browsing directly to http://localhost:8065/ will display a `404 Not Found` until the web app is configured. See [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for additional setup.
 
-    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop and clean up running docker containers:
+    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop the running docker containers:
 
     ```sh
     make stop-docker

--- a/site/content/contribute/server/developer-setup/windows.md
+++ b/site/content/contribute/server/developer-setup/windows.md
@@ -54,3 +54,9 @@
     If successful, the `curl` step will return a JSON object containing `"status":"OK"`.
 
     **Note:** Browsing directly to http://localhost:8065/ will display a `404 Not Found` until the web app is configured. See [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for additional setup.
+
+    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop and clean up running docker containers:
+
+    ```sh
+    make stop-docker
+    ```

--- a/site/content/contribute/server/developer-setup/windows.md
+++ b/site/content/contribute/server/developer-setup/windows.md
@@ -55,7 +55,7 @@
 
     **Note:** Browsing directly to http://localhost:8065/ will display a `404 Not Found` until the web app is configured. See [Web App Developer Setup](https://developers.mattermost.com/contribute/webapp/developer-setup/) and [Mobile App Developer Setup](https://developers.mattermost.com/contribute/mobile/developer-setup/) for additional setup.
 
-    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop and clean up running docker containers:
+    The `stop-server` make target does not stop all the docker containers started by `run-server`. To stop the running docker containers:
 
     ```sh
     make stop-docker


### PR DESCRIPTION
The developer docs mention `make stop-server` to stop the running server, but this does not stop the docker containers started by `make run-server`. 

Added a sentence about `make stop-docker` to stop and clean up the running docker containers. 