### PR TITLE
Fix wget command referencing Go src tarball instead of Linux one

### DIFF
--- a/site/content/contribute/server/developer-setup.md
+++ b/site/content/contribute/server/developer-setup.md
@@ -13,7 +13,7 @@ subsection: Server
     <button class="tablinks" onclick="openTab(event, 'windows')">Windows</button>
     <button class="tablinks" onclick="openTab(event, 'windows_wsl')">Windows WSL</button>
     <button class="tablinks" onclick="openTab(event, 'archlinux')">Archlinux</button>
-    <button class="tablinks" onclick="openTab(event, 'centos')">CentOS 7</button>
+    <button class="tablinks" onclick="openTab(event, 'centos')">CentOS 7/Fedora 31</button>
 </div>
 
 <div id="mac" class="tabcontent" style="display: block;">

--- a/site/content/contribute/server/developer-setup/centos.md
+++ b/site/content/contribute/server/developer-setup/centos.md
@@ -39,7 +39,7 @@
     sudo yum group install "Development Tools"
     sudo yum install -y wget libpng12
     sudo rm -rf /usr/local/go
-    wget https://dl.google.com/go/go1.13.3.src.tar.gz
+    wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz
     sudo tar -C /usr/local -xzf go1.13.3.linux-amd64.tar.gz
     ```
 

--- a/site/content/contribute/server/developer-setup/ubuntu.md
+++ b/site/content/contribute/server/developer-setup/ubuntu.md
@@ -36,8 +36,8 @@
 
     ```sh
     sudo apt-get install -y build-essential
-    wget https://dl.google.com/go/go1.13.3.src.tar.gz
     sudo rm -rf /usr/local/go
+    wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz
     sudo tar -C /usr/local -xzf go1.13.3.linux-amd64.tar.gz
     ```
 

--- a/site/content/contribute/server/developer-setup/windows-wsl.md
+++ b/site/content/contribute/server/developer-setup/windows-wsl.md
@@ -34,7 +34,7 @@ This is an unofficial guide. Community testing, feedback and improvements are we
     ```sh
     sudo apt-get install -y build-essential
     sudo rm -rf /usr/local/go
-    wget https://dl.google.com/go/go1.13.3.src.tar.gz
+    wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz
     sudo tar -C /usr/local -xzf go1.13.3.linux-amd64.tar.gz
     ```
 


### PR DESCRIPTION
Hello! :wave: 

This is my first PR, thanks a lot for reviewing it.

As I was going through the steps described in the [server dev setup document](https://developers.mattermost.com/contribute/server/developer-setup/), I noticed this minor mismatch where the `wget` command is downloading the Go source package and not the Linux one which is referenced in the `tar` command from the next line.

I have also added "Fedora 31" to the last tab since I am executing those steps on said distro. :slightly_smiling_face: 

Thanks!