### PR TITLE
addition of installation pre-requisites

### DIFF
--- a/site/content/contribute/webapp/developer-setup.md
+++ b/site/content/contribute/webapp/developer-setup.md
@@ -14,7 +14,7 @@ Set up your development environment for building, running, and testing the Matte
  - On Mac, use [Homebrew](https://brew.sh/) to install Node.js v10 and libpng:
 
     ```sh
-    brew install node@10 libpng
+    brew install node@10 libpng npm
     ```
 
  - For other platforms, install Node.js v10 from https://www.npmjs.com/get-npm.


### PR DESCRIPTION
#### Summary
Need of npm installation with brew, as `make test` command at line 44, calls `npm run test` from Makefile
#### Ticket Link
N/A
