### PR TITLE
Add Justine Geffen, Eric Sadur and Adam Clarkson to core committers + R&D staff list

### DIFF
--- a/site/content/contribute/getting-started/core-committers.md
+++ b/site/content/contribute/getting-started/core-committers.md
@@ -166,6 +166,8 @@ The core team also has product managers who do a lot of great work designing, pr
     - @aaron.rothschild on [community.mattermost.com](https://community.mattermost.com/core/messages/@aaron.rothschild) and [@aaronrothschild](https://github.com/aaronrothschild) on GitHub
 - **<a name="dennis.kittrell">Dennis Kittrell</a>**
     - @dennis.kittrell on [community.mattermost.com](https://community.mattermost.com/core/messages/@dennis.kittrell) and [@thefactremains](https://github.com/thefactremains) on GitHub
+- **<a name="eric.sadur">Eric Sadur</a>**
+    - @eric.sadur on [community.mattermost.com](https://community.mattermost.com/core/messages/@eric.sadur) and [@etoaster](https://github.com/etoaster) on GitHub
 - **<a name="adam.clarkson">Adam Clarkson</a>**
     - @adam.clarkson on [community.mattermost.com](https://community.mattermost.com/core/messages/@adam.clarkson) and [@adamjclarkson](https://github.com/adamjclarkson) on GitHub
 

--- a/site/content/contribute/getting-started/core-committers.md
+++ b/site/content/contribute/getting-started/core-committers.md
@@ -166,6 +166,8 @@ The core team also has product managers who do a lot of great work designing, pr
     - @aaron.rothschild on [community.mattermost.com](https://community.mattermost.com/core/messages/@aaron.rothschild) and [@aaronrothschild](https://github.com/aaronrothschild) on GitHub
 - **<a name="dennis.kittrell">Dennis Kittrell</a>**
     - @dennis.kittrell on [community.mattermost.com](https://community.mattermost.com/core/messages/@dennis.kittrell) and [@thefactremains](https://github.com/thefactremains) on GitHub
+- **<a name="adam.clarkson">Adam Clarkson</a>**
+    - @adam.clarkson on [community.mattermost.com](https://community.mattermost.com/core/messages/@adam.clarkson) and [@adamjclarkson](https://github.com/adamjclarkson) on GitHub
 
 QA Testers
 ------------
@@ -190,3 +192,11 @@ The core team also has QA testers who verify the correct functionality of the pr
     - @jelena.gilliam on [community.mattermost.com](https://community.mattermost.com/core/messages/@jelena.gilliam) and [@jgilliam17](https://github.com/jgilliam17) on GitHub
 - **<a name="steve.mudie">Steve Mudie</a>**
     - @steve.mudie on [community.mattermost.com](https://community.mattermost.com/core/messages/@steve.mudie) and [@stevemudie](https://github.com/stevemudie) on GitHub
+
+Technical Writers
+--------------------
+
+The core team also has technical writers who document product features and functionality from release to release, along with product managers. They are:
+
+- **<a name="justine.geffen">Justine Geffen</a>**
+    - @justine.geffen on [community.mattermost.com](https://community.mattermost.com/core/messages/@justine.geffen) and [@justinegeffen](https://github.com/justinegeffen) on GitHub

--- a/site/content/internal/rd-teams.md
+++ b/site/content/internal/rd-teams.md
@@ -103,3 +103,6 @@ weight: 110
 * Jelena Gilliam - QA
 * Ogi Marusic - QA
 * Steve Mudie - QA
+* Justine Geffen - Technical Writer
+* Adam Clarkson - PM
+* Eric Sadur - PM


### PR DESCRIPTION
I'm not sure who usually reviews, but I see @lieut-data you've made some changes recently so requesting your review. Amy's for editor review.

----

FYI @justinegeffen @adamjclarkson @etoaster 

Adam/Eric: For R&D list, I added you under "Other" while we figure out how the new product and engineer structure work together.