### PR TITLE
update build status badge to point to current one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mattermost Developer Documentation [![Build Status](https://travis-ci.org/mattermost/mattermost-developer-documentation.svg?branch=master)](https://travis-ci.org/mattermost/mattermost-developer-documentation)
+# Mattermost Developer Documentation [![Mattermost dev docs status badge](https://circleci.com/gh/mattermost/mattermost-developer-documentation.svg?style=svg)](https://circleci.com/gh/mattermost/mattermost-developer-documentation/tree/master)
 
 Website for Mattermost developer documentation, built using [Hugo](https://gohugo.io/). Master is continuously deployed to [developers.mattermost.com](https://developers.mattermost.com/).
 


### PR DESCRIPTION
#### Summary

I've updated the build status badge in the readme given that automatic builds are now run at CircleCI: https://github.com/mattermost/mattermost-developer-documentation/commit/25f30e65d5087cfd1252bfabdb97fa447c20b2fc

#### Ticket

none
