### PR TITLE
Allow two authors in Developers Blog

### DIFF
--- a/site/content/internal/writing-a-blog-post.md
+++ b/site/content/internal/writing-a-blog-post.md
@@ -78,6 +78,6 @@ The steps below outline the process involved in creating the blog post file from
     ```
 
 4. Write your blog post.
-5. (Optional) If you wrote the blog post with someone else, you can also add a second author by adding `author_2`, `github_2` and `community_2` to the front matter.
+5. (Optional) If you wrote the blog post with someone else, you can also add a second author by adding `author_2`, `github_2` and `community_2` to the [front matter](https://gohugo.io/content-management/front-matter).
 6. Submit a pull request to https://github.com/mattermost/mattermost-developer-documentation and assign two dev reviews and an editor review from @amyblais or @justinegeffen.
 7. Once merged it should show up on [developers.mattermost.com/blog](https://developers.mattermost.com/blog) within 10-15 minutes. When it shows up, post about it in the Developers channel on community.mattermost.com.

--- a/site/content/internal/writing-a-blog-post.md
+++ b/site/content/internal/writing-a-blog-post.md
@@ -78,6 +78,6 @@ The steps below outline the process involved in creating the blog post file from
     ```
 
 4. Write your blog post.
-5. (Optional) If you did write the blog post with someone else, you can also add a second author by adding `author_2`, `github_2` and `community_2` to the front matter.
+5. (Optional) If you wrote the blog post with someone else, you can also add a second author by adding `author_2`, `github_2` and `community_2` to the front matter.
 6. Submit a pull request to https://github.com/mattermost/mattermost-developer-documentation and assign two dev reviews and an editor review from @amyblais or @justinegeffen.
 7. Once merged it should show up on [developers.mattermost.com/blog](https://developers.mattermost.com/blog) within 10-15 minutes. When it shows up, post about it in the Developers channel on community.mattermost.com.

--- a/site/content/internal/writing-a-blog-post.md
+++ b/site/content/internal/writing-a-blog-post.md
@@ -77,6 +77,7 @@ The steps below outline the process involved in creating the blog post file from
     <some more content>
     ```
 
-4. Write your blog post. 
-5. Submit a pull request to https://github.com/mattermost/mattermost-developer-documentation and assign two dev reviews and an editor review from @amyblais or @justinegeffen.
-6. Once merged it should show up on [developers.mattermost.com/blog](https://developers.mattermost.com/blog) within 10-15 minutes. When it shows up, post about it in the Developers channel on community.mattermost.com.
+4. Write your blog post.
+5. (Optional) If you did write the blog post with someone else, you can also add a second author by adding `author_2`, `github_2` and `community_2` to the front matter.
+6. Submit a pull request to https://github.com/mattermost/mattermost-developer-documentation and assign two dev reviews and an editor review from @amyblais or @justinegeffen.
+7. Once merged it should show up on [developers.mattermost.com/blog](https://developers.mattermost.com/blog) within 10-15 minutes. When it shows up, post about it in the Developers channel on community.mattermost.com.

--- a/site/layouts/blog/single.html
+++ b/site/layouts/blog/single.html
@@ -26,13 +26,22 @@
                     <hr>
                     {{ partial "hanchor.html" .Content }}
                     <hr>
-                    Written by {{.Params.author}} -
-                    <a href="https://community.mattermost.com/core/messages/@{{.Params.community}}" target="_blank">@{{.Params.community}}</a>
-                    on
-                    <a href="https://community.mattermost.com/signup_user_complete/?id=f1924a8db44ff3bb41c96424cdc20676"
-                        target="_blank">community.mattermost.com</a>
-                    and <a href="https://github.com/{{.Params.github}}" target="_blank">@{{.Params.github}}</a> on
-                    GitHub
+                    {{ if and (and .Params.author .Params.github) .Params.community }}
+                    Written by
+                    {{ if and (and .Params.author_2 .Params.github_2) .Params.community_2 }}
+                    :
+                    <ul>
+                        <li>
+                            {{ partial "blogauthor" (dict "name" .Params.author "community" .Params.community "github" .Params.github) }}
+                        </li>
+                        <li>
+                            {{ partial "blogauthor" (dict "name" .Params.author_2 "community" .Params.community_2 "github" .Params.github_2) }}
+                        </li>
+                    </ul>
+                    {{ else }}
+                    {{ partial "blogauthor" (dict "name" .Params.author "community" .Params.community "github" .Params.github) }}
+                    {{ end }}
+                    {{ end }}
                     <br />
                     <br />
                     Join us on <a href="https://community.mattermost.com/signup_user_complete/?id=f1924a8db44ff3bb41c96424cdc20676"

--- a/site/layouts/partials/blogauthor.html
+++ b/site/layouts/partials/blogauthor.html
@@ -1,0 +1,14 @@
+{{ .name }}
+-
+<a href="https://community.mattermost.com/core/messages/@{{ .community }}" target="_blank">
+    @{{ .community }}
+</a>
+on
+<a href="https://community.mattermost.com/signup_user_complete/?id=f1924a8db44ff3bb41c96424cdc20676" target="_blank">
+    community.mattermost.com
+</a>
+and
+<a href="https://github.com/{{ .github  }}" target="_blank">
+    @{{ .github  }}
+</a>
+on GitHub


### PR DESCRIPTION
#### Summary
Blog posts can now be mention more the one author. This is done by setting `author_2`, `github_2` and `community_2` in the front matter. While this approach is a bit hacky, it allows backwards compatibility.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21533