### PR TITLE
when checkout fetch the all history

### DIFF
--- a/.github/workflows/notify-mm-blog.yml
+++ b/.github/workflows/notify-mm-blog.yml
@@ -1,7 +1,7 @@
 name: notify-mm-blog
 on:
   push:
-    branches: 
+    branches:
       - master
     paths:
       - 'site/content/blog/**'
@@ -10,7 +10,9 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - shell: bash
         run: |
           set -x


### PR DESCRIPTION
#### Summary
The GH action that checkout the repo by default (now) just check out the current commit and we need more history to compare what changed.

This Pr fix this issue https://github.com/mattermost/mattermost-developer-documentation/commit/c2f917b9dfbf482ebe3e38811f9c4bfdc7e3acb7/checks?check_suite_id=393748998
