### PR TITLE
Fix gh actions for blog posts

### DIFF
--- a/.github/workflows/notify-mm-blog.yml
+++ b/.github/workflows/notify-mm-blog.yml
@@ -24,10 +24,10 @@ jobs:
             echo "nothing added in the .md"
             exit 0
           fi
-          FILENAME=$(cat $FILEADDED | grep slug | cut -d':' -f 2 | sed 's/^ *//g')
-          TITLE=$(cat $FILEADDED | grep title | cut -d':' -f 2 | sed 's/^ *//g')
-          AUTHOR=$(cat $FILEADDED | grep author | cut -d':' -f 2 | sed 's/^ *//g')
-          AUTHOR_GH=$(cat $FILEADDED | grep github | cut -d':' -f 2 | sed 's/^ *//g')
+          FILENAME=$(cat $FILEADDED | grep slug: | cut -d':' -f 2 | sed 's/^ *//g')
+          TITLE=$(cat $FILEADDED | grep title: | cut -d':' -f 2 | sed 's/^ *//g')
+          AUTHOR=$(cat $FILEADDED | grep author: | cut -d':' -f 2 | sed 's/^ *//g')
+          AUTHOR_GH=$(cat $FILEADDED | grep github: | cut -d':' -f 2 | sed 's/^ *//g')
           echo "{\"username\":\"GitHub Action Notify\",\"icon_url\":\"https://www.mattermost.org/wp-content/uploads/2016/04/icon.png\",\"attachments\":[{\"author_name\":\"$AUTHOR\",\"author_link\":\"https://github.com/$AUTHOR_GH\",\"fallback\":\"New Blog Post! Check out [here](https://developers.mattermost.com/blog/)\",\"color\":\"good\",\"title\":\""$TITLE"\",\"text\":\"New Blog Post! Check out [here](https://developers.mattermost.com/blog/$FILENAME)\"}]}" > mattermost.json
 
       - uses: mattermost/action-mattermost-notify@master


### PR DESCRIPTION
#### Summary
Make sure to only `grep` metadata from the Front Matter, not the complete blog post. I've triggered the action for the last two posts manually.