### PR TITLE
MM-21107: eliminate duplicate API listing

### DIFF
--- a/cmd/plugin-godocs/plugin-godocs.go
+++ b/cmd/plugin-godocs/plugin-godocs.go
@@ -128,6 +128,10 @@ func generateDocs() (*Docs, error) {
 		Examples: make(map[string]*ExampleDocs),
 	}
 
+	// With Tests enabled in the config above, we see up to four duplicate packages. Keep
+	// track of the types seen to avoid rendering them more than once.
+	seenTypes := make(map[string]bool)
+
 	for _, pkg := range pkgs {
 		for _, example := range doc.Examples(pkg.Syntax...) {
 			buf := &bytes.Buffer{}
@@ -155,6 +159,11 @@ func generateDocs() (*Docs, error) {
 		}
 
 		for _, t := range godocs.Types {
+			if seenTypes[t.Name] {
+				continue
+			}
+			seenTypes[t.Name] = true
+
 			var interfaceDocs *InterfaceDocs
 			switch t.Name {
 			case "API":


### PR DESCRIPTION
#### Summary
Keep track of the types seen to avoid listing duplicates. The duplicates are seen as a result of needing to iterate over the test variation of the package to extract examples and such.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost-developer-documentation/issues/460
Fixes: https://mattermost.atlassian.net/browse/MM-21107