### PR TITLE
Stopped the `):` from getting absorbed into the link

### DIFF
--- a/site/content/contribute/server/developer-setup/ubuntu.md
+++ b/site/content/contribute/server/developer-setup/ubuntu.md
@@ -32,7 +32,7 @@
     sudo chmod +x /usr/local/bin/docker-compose
     ```
 
-3. Install Go (modify installation to latest Go version from https://golang.org/dl/):
+3. Install Go (modify installation to latest Go version from <https://golang.org/dl/>):
 
     ```sh
     sudo apt-get install -y build-essential


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This change delimits a link with less-than, greater-than symbols "< >" to avoid surrounding text from being absorbed into it.  In my tests,

```
3. Install Go (modify installation to latest Go version from https://golang.org/dl/):
```
effectively had a link at the end pointing to `https://golang.org/dl/):` instead of the intended `https://golang.org/dl/`. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
None.  Minor fix.
