### PR TITLE
Allow "unsafe" mode to use html in hugo source

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -142,7 +142,7 @@ pygmentsStyle = "manni"
     youtube = 'https://www.youtube.com/channel/UCNR05H72hi692y01bWaFXNA'
     copyright = '&copy; Mattermost, Inc. All Rights Reserved.'
 
-# Allows html Hugo >= v0.60.0
+# Allows html in Hugo >= v0.60.0
 [markup]
   [markup.goldmark]
     [markup.goldmark.renderer]

--- a/site/config.toml
+++ b/site/config.toml
@@ -141,3 +141,9 @@ pygmentsStyle = "manni"
     facebook = 'https://www.facebook.com/Mattermost-2300985916642531/'
     youtube = 'https://www.youtube.com/channel/UCNR05H72hi692y01bWaFXNA'
     copyright = '&copy; Mattermost, Inc. All Rights Reserved.'
+
+# Allows html Hugo >= v0.60.0
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true

--- a/site/config.toml
+++ b/site/config.toml
@@ -142,7 +142,7 @@ pygmentsStyle = "manni"
     youtube = 'https://www.youtube.com/channel/UCNR05H72hi692y01bWaFXNA'
     copyright = '&copy; Mattermost, Inc. All Rights Reserved.'
 
-# Allows html in Hugo >= v0.60.0
+# Allows html in Hugo >= v0.60.0.  See Github issue #506.
 [markup]
   [markup.goldmark]
     [markup.goldmark.renderer]

--- a/site/content/contribute/server/developer-setup.md
+++ b/site/content/contribute/server/developer-setup.md
@@ -3,10 +3,6 @@ title: "Developer Setup"
 date: 2017-08-20T11:35:32-04:00
 weight: 2
 subsection: Server
-markup:
-  goldmark:
-    renderer:
-      unsafe: true
 ---
 
 <p>Set up your development environment for building, running, and testing the Mattermost server.</p>

--- a/site/content/contribute/server/developer-setup.md
+++ b/site/content/contribute/server/developer-setup.md
@@ -3,6 +3,10 @@ title: "Developer Setup"
 date: 2017-08-20T11:35:32-04:00
 weight: 2
 subsection: Server
+markup:
+  goldmark:
+    renderer:
+      unsafe: true
 ---
 
 <p>Set up your development environment for building, running, and testing the Mattermost server.</p>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Hugo v0.60.0 switched from Blackfriday to Goldmark.  In this transition, they disabled some html tags in markdown files.  This allows html.

https://gohugo.io/news/0.60.0-relnotes/

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-developer-documentation/issues/506
