### PR TITLE
Revert "Bump hugo version to 0.62.2 (#494)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: build Hugo
           environment:
-            HUGO_VERSION: 0.62.2
+            HUGO_VERSION: 0.58.3
           command: |
             wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -O /tmp/hugo.tar.gz
             tar -xvf /tmp/hugo.tar.gz hugo


### PR DESCRIPTION
#### Summary
https://developers.mattermost.com/contribute/server/developer-setup/ was broken with https://github.com/mattermost/mattermost-developer-documentation/pull/494 and the quick fix in https://github.com/mattermost/mattermost-developer-documentation/pull/508 did work on my local instance.

Let's just revert the change and fix all issues _when_ bumping the hugo version in the future.

#### Ticket Link
https://community-release.mattermost.com/core/pl/3izsnipc8inymdar4twpi5wioe
