### PR TITLE
Bump hugo version to 0.62.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: build Hugo
           environment:
-            HUGO_VERSION: 0.58.3
+            HUGO_VERSION: 0.62.2
           command: |
             wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -O /tmp/hugo.tar.gz
             tar -xvf /tmp/hugo.tar.gz hugo


### PR DESCRIPTION
#### Summary
Re submission of https://github.com/mattermost/mattermost-developer-documentation/pull/494.

Despite the issues that occurred when bumping the version the first time, I still consider it important to stay up to date with the latest Hugo version, because developers often update their local version and might encounter issues.