### PR TITLE
Update link in "getting started" page

### DIFF
--- a/site/content/contribute/getting-started/_index.md
+++ b/site/content/contribute/getting-started/_index.md
@@ -10,7 +10,7 @@ We're very glad you want to join hundreds of community members who have contribu
 
 Our goal is to make your experience as great as possible. Follow these simple steps to contribute:
 
-{{< bignumber number="1" title="Sign up to our Mattermost site" content="Go to [community.mattermost.com](https://community.mattermost.com/signup_user_complete/?id=f1924a8db44ff3bb41c96424cdc20676) and join the [Developers](https://community.mattermost.com/core/channels/developers) and [Contributors](https://community.mattermost.com/core/channels/tickets) channels to ask questions." >}}
+{{< bignumber number="1" title="Sign up to our Mattermost site" content="Go to [community.mattermost.com](https://community.mattermost.com) and join the [Developers](https://community.mattermost.com/core/channels/developers) and [Contributors](https://community.mattermost.com/core/channels/tickets) channels to ask questions." >}}
 
 
 {{< bignumber number="2" title="Choose which project you want to contribute to" content="Click through them in the sidebar on the left. If you're not sure, try starting with the [server project](/contribute/server), which offers an easy way to introduce you to the codebase." >}}

--- a/site/content/contribute/getting-started/_index.md
+++ b/site/content/contribute/getting-started/_index.md
@@ -10,7 +10,7 @@ We're very glad you want to join hundreds of community members who have contribu
 
 Our goal is to make your experience as great as possible. Follow these simple steps to contribute:
 
-{{< bignumber number="1" title="Sign up to our Mattermost site" content="Go to [community.mattermost.com](https://community.mattermost.com) and join the [Developers](https://community.mattermost.com/core/channels/developers) and [Contributors](https://community.mattermost.com/core/channels/tickets) channels to ask questions." >}}
+{{< bignumber number="1" title="Sign up to our Mattermost site" content="Go to [community.mattermost.com](https://community.mattermost.com/signup_user_complete) and join the [Developers](https://community.mattermost.com/core/channels/developers) and [Contributors](https://community.mattermost.com/core/channels/tickets) channels to ask questions." >}}
 
 
 {{< bignumber number="2" title="Choose which project you want to contribute to" content="Click through them in the sidebar on the left. If you're not sure, try starting with the [server project](/contribute/server), which offers an easy way to introduce you to the codebase." >}}


### PR DESCRIPTION
Fixes https://github.com/mattermost/mattermost-server/issues/13750.

I removed the signup link in case this bug happens again.