### PR TITLE
Add make run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: dist 
-dist: #plugin-data
+dist: plugin-data
 	rm -rf ./dist
 	hugo -s site --destination ../dist/html
 
@@ -29,7 +29,7 @@ endif
 
 .PHONY: run
 run:
-	hugo server -s site
+	hugo server --buildDrafts -s site
 
 .PHONY: dev
 dev: run

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,18 @@
-.PHONY: dist plugin-data backend-plugin-data frontend-plugin-data
-
-dist: plugin-data
+.PHONY: dist 
+dist: #plugin-data
 	rm -rf ./dist
-	cd site && hugo --destination ../dist/html
+	hugo -s site --destination ../dist/html
 
+.PHONY: plugin-data
 plugin-data: backend-plugin-data frontend-plugin-data devtalks-data
 
+.PHONY: backend-plugin-data
 backend-plugin-data:
 	mkdir -p site/data
 	go run ./cmd/plugin-godocs > site/data/PluginGoDocs.json
 	go run ./cmd/plugin-manifest-docs > site/data/PluginManifestDocs.json
 
+.PHONY: frontend-plugin-data
 frontend-plugin-data:
 	rm -rf scripts/mattermost-webapp
 	cd scripts && git clone https://github.com/mattermost/mattermost-webapp.git
@@ -18,11 +20,16 @@ frontend-plugin-data:
 	mkdir -p site/data
 	node scripts/plugin-jsdocs.js > site/data/PluginJSDocs.json
 
+.PHONY: frontend-plugin-data
 devtalks-data:
 	mkdir -p site/data
 ifdef YOUTUBE_API_KEY
 	go run ./cmd/devtalks > site/data/DevTalks.json
 endif
 
-dev:
-	cd site && hugo server -D
+.PHONY: run
+run:
+	hugo server -s site
+
+.PHONY: dev
+dev: run

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+include legacy.mk
+
 .PHONY: dist 
 dist: plugin-data
 	rm -rf ./dist
@@ -30,8 +32,3 @@ endif
 .PHONY: run
 run:
 	hugo server --buildDrafts -s site
-
-.PHONY: dev
-dev:
-	@echo '****** make dev is DEPRECATED, use make run instead ******'
-	make run

--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,6 @@ run:
 	hugo server --buildDrafts -s site
 
 .PHONY: dev
-dev: run
+dev:
+	@echo '****** make dev is DEPRECATED, use make run instead ******'
+	make run

--- a/legacy.mk
+++ b/legacy.mk
@@ -1,0 +1,4 @@
+.PHONY: dev
+dev:
+	@echo '****** make dev is DEPRECATED, use make run instead ******'
+	make run


### PR DESCRIPTION
#### Summary
- Place `.PHONY` in front of each target to ensure it doesn't get forgotten
- Make use of `hugo -s` to set the source
- Add `make run` as an alias of `make dev`, as `make run` is the more common term