### PR TITLE
Adjust formatting for "Install dependencies"

### DIFF
--- a/site/content/contribute/webapp/developer-setup.md
+++ b/site/content/contribute/webapp/developer-setup.md
@@ -9,17 +9,17 @@ Set up your development environment for building, running, and testing the Matte
 
 1. Set up your [development environment for the Mattermost server](/contribute/server/developer-setup).
 
-2. Install dependencies
+2. Install dependencies:
 
- - On Mac, use [Homebrew](https://brew.sh/) to install Node.js v10 and libpng:
+    - On Mac, use [Homebrew](https://brew.sh/) to install Node.js v10 and libpng:
 
-    ```sh
-    brew install node@10 libpng
-    ```
+        ```sh
+        brew install node@10 libpng
+        ```
 
- - For other platforms, install Node.js v10 from https://www.npmjs.com/get-npm.
+    - For other platforms, install Node.js v10 from https://www.npmjs.com/get-npm.
 
- - Prefer to use [NVM](https://github.com/nvm-sh/nvm) to manage different versions of Node on a given machine? Ensure you're running Node v10.15.3+ and npm v6.4.1+ to [avoid compatibility-related Jest test failures](/contribute/webapp/unit-testing/#4-getting-jest-assertion-failures-at-lines-containing-expect-tobecalledwith-expect-tohavebeennthcalledwith-or-expect-tohavebeencalledtimes-when-running-make-test).
+    - Prefer to use [NVM](https://github.com/nvm-sh/nvm) to manage different versions of Node on a given machine? Ensure you're running Node v10.15.3+ and npm v6.4.1+ to [avoid compatibility-related Jest test failures](/contribute/webapp/unit-testing/#4-getting-jest-assertion-failures-at-lines-containing-expect-tobecalledwith-expect-tohavebeennthcalledwith-or-expect-tohavebeencalledtimes-when-running-make-test).
 
 3. Fork https://github.com/mattermost/mattermost-webapp
 

--- a/site/content/contribute/webapp/developer-setup.md
+++ b/site/content/contribute/webapp/developer-setup.md
@@ -43,8 +43,15 @@ Set up your development environment for building, running, and testing the Matte
     cd mattermost-webapp
     make test
     ```
+7. When tests pass, run the app: 
 
-7. (Optional) Enable live reload functionality to refresh the webapp as you edit the source code. First, install and enable live reload script injection extension for your web browser ([Chrome](https://chrome.google.com/webstore/detail/remotelivereload/jlppknnillhjgiengoigajegdpieppei/related?hl=en) | [Firefox](https://addons.mozilla.org/en-US/firefox/addon/livereload-web-extension/)), then run (before running webpack):
+     ```sh
+    make run
+    ```
+
+    Refreshing http://localhost:8065 should now load the UI.
+
+    If you would like the webapp to automatically refresh as you edit the source code you can install and enable the live reload script injection extension for your web browser ([Chrome](https://chrome.google.com/webstore/detail/remotelivereload/jlppknnillhjgiengoigajegdpieppei/related?hl=en) | [Firefox](https://addons.mozilla.org/en-US/firefox/addon/livereload-web-extension/)). Then, before running webpack run:
 
     ```sh
     export MM_LIVE_RELOAD=true


### PR DESCRIPTION
While running through installation it took a moment to understand that "Install dependencies" wasn't a separate instruction from the bullet points below it. Adding an indentation to the bullet points and a colon after "Install dependencies" makes this more clear imo.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

