### PR TITLE
Add missing `make config-reset` to "useful make commands" in developer-workflow

### DIFF
--- a/site/content/contribute/server/developer-workflow.md
+++ b/site/content/contribute/server/developer-workflow.md
@@ -43,6 +43,7 @@ Some useful `make` commands:
 * `make stop-server` stops only the server.
 * `make clean-docker` stops and removes your Docker images and is a good way to wipe your database.
 * `make clean` cleans your local environment of temporary files.
+* `make config-reset` resets your local config files like `config/config.json`
 * `make nuke` wipes your local environment back to a completely fresh start.
 * `make package` creates packages for distributing your builds and puts them in the `~/go/src/github.com/mattermost/mattermost-server/dist` directory. First you will need to run `make build` and `make build-client`.
 * `make megacheck` runs the tool [megacheck](https://github.com/dominikh/go-tools/tree/master/cmd/megacheck) against the code base to find potential issues in the code. Please note the results are guidelines, and not mandatory in all cases. If in doubt, ask in the [Developers community channel](https://community.mattermost.com/core/channels/developers).

--- a/site/content/contribute/server/developer-workflow.md
+++ b/site/content/contribute/server/developer-workflow.md
@@ -43,7 +43,7 @@ Some useful `make` commands:
 * `make stop-server` stops only the server.
 * `make clean-docker` stops and removes your Docker images and is a good way to wipe your database.
 * `make clean` cleans your local environment of temporary files.
-* `make config-reset` resets your local config files like `config/config.json`
+* `make config-reset` resets the `config/config.json` file to the default.
 * `make nuke` wipes your local environment back to a completely fresh start.
 * `make package` creates packages for distributing your builds and puts them in the `~/go/src/github.com/mattermost/mattermost-server/dist` directory. First you will need to run `make build` and `make build-client`.
 * `make megacheck` runs the tool [megacheck](https://github.com/dominikh/go-tools/tree/master/cmd/megacheck) against the code base to find potential issues in the code. Please note the results are guidelines, and not mandatory in all cases. If in doubt, ask in the [Developers community channel](https://community.mattermost.com/core/channels/developers).


### PR DESCRIPTION
…
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
I was [chatting with Jesse Hallam](https://community.mattermost.com/core/pl/q5om5tphxbgj3gmfa9368zqjyh) who recommended this command.  When I went to go read documentation on it, I [couldn't find it anywhere](https://www.google.com/search?q=site:developers.mattermost.com+%22make+config-reset%22).  This seemed like a good place for it so others know about it!

#### Ticket Link
This is a one line fix, so there's no ticket.  I believe this is OK [per the guidelines](https://developers.mattermost.com/contribute/getting-started/contributions-without-ticket/), but lemme know if not!

