### PR TITLE
Fix quoting issue.

### DIFF
--- a/.github/workflows/notify-mm-blog.yml
+++ b/.github/workflows/notify-mm-blog.yml
@@ -27,11 +27,11 @@ jobs:
           fi
           FILENAME=$(cat $FILEADDED | grep slug: | cut -d':' -f 2 | sed 's/^ *//g')
           TITLE=$(cat $FILEADDED | grep title: | cut -d':' -f 2 | sed 's/^ *//g')
-          TITLE="${TITLE%\"}" # remove suffix quote
-          TITLE="${TITLE#\"}" # remove prefix quote
+          TITLE="${TITLE%\"'}" # remove suffix quote
+          TITLE="${TITLE#\'"}" # remove prefix quote
           AUTHOR=$(cat $FILEADDED | grep author: | cut -d':' -f 2 | sed 's/^ *//g')
           AUTHOR_GH=$(cat $FILEADDED | grep github: | cut -d':' -f 2 | sed 's/^ *//g')
-          echo "{\"username\":\"GitHub Action Notify\",\"icon_url\":\"https://www.mattermost.org/wp-content/uploads/2016/04/icon.png\",\"attachments\":[{\"author_name\":\"$AUTHOR\",\"author_link\":\"https://github.com/$AUTHOR_GH\",\"fallback\":\"New Blog Post! Check out [here](https://developers.mattermost.com/blog/)\",\"color\":\"good\",\"title\":\""$TITLE"\",\"text\":\"New Blog Post! Check out [here](https://developers.mattermost.com/blog/$FILENAME)\"}]}" > mattermost.json
+          echo "{\"username\":\"GitHub Action Notify\",\"icon_url\":\"https://www.mattermost.org/wp-content/uploads/2016/04/icon.png\",\"attachments\":[{\"author_name\":\"$AUTHOR\",\"author_link\":\"https://github.com/$AUTHOR_GH\",\"fallback\":\"New Blog Post! Check out [here](https://developers.mattermost.com/blog/)\",\"color\":\"good\",\"title\":\"$TITLE\",\"text\":\"New Blog Post! Check out [here](https://developers.mattermost.com/blog/$FILENAME)\"}]}" > mattermost.json
 
       - uses: mattermost/action-mattermost-notify@master
         env:

--- a/.github/workflows/notify-mm-blog.yml
+++ b/.github/workflows/notify-mm-blog.yml
@@ -27,6 +27,8 @@ jobs:
           fi
           FILENAME=$(cat $FILEADDED | grep slug: | cut -d':' -f 2 | sed 's/^ *//g')
           TITLE=$(cat $FILEADDED | grep title: | cut -d':' -f 2 | sed 's/^ *//g')
+          TITLE="${TITLE%\"}" # remove suffix quote
+          TITLE="${TITLE#\"}" # remove prefix quote
           AUTHOR=$(cat $FILEADDED | grep author: | cut -d':' -f 2 | sed 's/^ *//g')
           AUTHOR_GH=$(cat $FILEADDED | grep github: | cut -d':' -f 2 | sed 's/^ *//g')
           echo "{\"username\":\"GitHub Action Notify\",\"icon_url\":\"https://www.mattermost.org/wp-content/uploads/2016/04/icon.png\",\"attachments\":[{\"author_name\":\"$AUTHOR\",\"author_link\":\"https://github.com/$AUTHOR_GH\",\"fallback\":\"New Blog Post! Check out [here](https://developers.mattermost.com/blog/)\",\"color\":\"good\",\"title\":\""$TITLE"\",\"text\":\"New Blog Post! Check out [here](https://developers.mattermost.com/blog/$FILENAME)\"}]}" > mattermost.json


### PR DESCRIPTION
#### Summary
Adding double quotes to the blog title is causing issues with deployment. 
Added trimming of additional quotes for the blog title in the pipeline. 