### PR TITLE
Bump hugo version to 0.67.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: build Hugo
           environment:
-            HUGO_VERSION: 0.62.2
+            HUGO_VERSION: 0.67.1
           command: |
             wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -O /tmp/hugo.tar.gz
             tar -xvf /tmp/hugo.tar.gz hugo


### PR DESCRIPTION
#### Summary
As reported by @cpoile https://developers.mattermost.com/integrate/incoming-webhooks/ doesn't render the http code sample correctly. This was broken in Hugo `v0.59.0` and was fixed in Hugo `v0.65.0`. The bug report is https://github.com/gohugoio/hugo/issues/6877.

I opted to upgrade to `0.67.1`, because I would like to stay up to date with the version devs use. 1/5


#### Ticket Link
https://community.mattermost.com/core/pl/oadox9mwj788jq1bch1hyou5za
