### PR TITLE
Addresses Request for Documentation: Typo in plugin webapp developer documentation #489

### DIFF
--- a/site/content/extend/plugins/webapp/reference.md
+++ b/site/content/extend/plugins/webapp/reference.md
@@ -161,8 +161,8 @@ Converts HTML to React components.
 A short usage example of a `PostType` component using the post utility functions to format text.
 
 ```javascript
-const React = window.react;
-const PostUtils = window['post-utils']; // import the post utilities
+const React = window.React;
+const PostUtils = window.PostUtils; // import the post utilities
 import PropTypes from 'prop-types';
 import {makeStyleFromTheme} from 'mattermost-redux/utils/theme_utils';
 

--- a/site/content/extend/plugins/webapp/reference.md
+++ b/site/content/extend/plugins/webapp/reference.md
@@ -163,7 +163,7 @@ A short usage example of a `PostType` component using the post utility functions
 ```javascript
 const React = window.React;
 const PostUtils = window.PostUtils; // import the post utilities
-import PropTypes from 'prop-types';
+const PropTypes = window.PropTypes;
 import {makeStyleFromTheme} from 'mattermost-redux/utils/theme_utils';
 
 export default class PostTypeFormatted extends React.PureComponent {

--- a/site/content/extend/plugins/webapp/reference.md
+++ b/site/content/extend/plugins/webapp/reference.md
@@ -161,10 +161,10 @@ Converts HTML to React components.
 A short usage example of a `PostType` component using the post utility functions to format text.
 
 ```javascript
-const React = window.React;
-const PostUtils = window.PostUtils; // import the post utilities
-const PropTypes = window.PropTypes;
+import React from 'react'; // accessed through webpack externals
+import PropTypes from 'prop-types';
 import {makeStyleFromTheme} from 'mattermost-redux/utils/theme_utils';
+const PostUtils = window.PostUtils; // must be accessed through `window`
 
 export default class PostTypeFormatted extends React.PureComponent {
 


### PR DESCRIPTION
#### Summary
Fixing import paths in plugin webapp documentation.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-developer-documentation/issues/489

