### PR TITLE
MM-23588: Document i18n-extract in Server workflow

### DIFF
--- a/site/content/contribute/server/developer-workflow.md
+++ b/site/content/contribute/server/developer-workflow.md
@@ -20,7 +20,7 @@ Here's a general workflow for a Mattermost developer working on the [mattermost-
     * [./utils/](https://github.com/mattermost/mattermost-server/tree/master/utils) holds all utilities, such as the mail utility.
     * [./i18n/](https://github.com/mattermost/mattermost-server/tree/master/i18n) holds all localization files for the server.
 2. On your fork, create a feature branch for your changes. Name it `MM-$NUMBER_$DESCRIPTION` where `$NUMBER` is the [Jira](https://mattermost.atlassian.net) ticket number you are working on and `$DESCRIPTION` is a short description of your changes. Example branch names are `MM-18150_plugin-panic-log` and `MM-22037_uppercase-email`.
-3. Make the code changes required to complete your ticket, ensuring that unit tests are written or modified  where appropriate. Please use [testify](https://github.com/stretchr/testify) for new tests.
+3. Make the code changes required to complete your ticket, ensuring that unit tests are written or modified where appropriate. Please use [testify](https://github.com/stretchr/testify) for new tests.
 4. To test your changes, run `make run-server` from the root directory of the server respository. This will start up the server at `http://localhost:8065`. To get changes to the server it must be restarted with `make restart-server`. If you want to test with the web app, you may also run `make run` which will start the server and a watcher for changes to the web app.
 5. Once everything works to meet the ticket requirements, stop Mattermost by running `make stop` in the server repository, then run `make check-style` to check your syntax.
 6. Run the tests using one or more of the following options:
@@ -28,9 +28,10 @@ Here's a general workflow for a Mattermost developer working on the [mattermost-
      * Run individual tests by name executing `go test -run "TestName"`.
      * Run all the tests in a package where changes were made executing `go test app`.
      * Create a draft PR with your changes and let our CI servers run the tests for you.
-7. Commit your changes, push your branch, and [create a pull request](https://developers.mattermost.com/contribute/getting-started/contribution-checklist/).
-8. Respond to feedback on your pull request and make changes as necessary by commiting to your branch and pushing it. You might need to [rebase your changes](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) if another pull request creates conflicts.
-9. That's it! Rejoice that you've helped make Mattermost better.
+7. If you added or changed any localization strings you will need to run `make i18n-extract` to generate the new/updated strings.
+8. Commit your changes, push your branch, and [create a pull request](https://developers.mattermost.com/contribute/getting-started/contribution-checklist/).
+9. Respond to feedback on your pull request and make changes as necessary by commiting to your branch and pushing it. You might need to [rebase your changes](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) if another pull request creates conflicts.
+10. That's it! Rejoice that you've helped make Mattermost better.
 
 ### Useful Server Makefile Commands
 

--- a/site/content/contribute/server/developer-workflow.md
+++ b/site/content/contribute/server/developer-workflow.md
@@ -30,7 +30,7 @@ Here's a general workflow for a Mattermost developer working on the [mattermost-
      * Create a draft PR with your changes and let our CI servers run the tests for you.
 7. If you added or changed any localization strings you will need to run `make i18n-extract` to generate the new/updated strings.
 8. Commit your changes, push your branch, and [create a pull request](https://developers.mattermost.com/contribute/getting-started/contribution-checklist/).
-9. Respond to feedback on your pull request and make changes as necessary by commiting to your branch and pushing it. You might need to [rebase your changes](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) if another pull request creates conflicts.
+9. Respond to feedback on your pull request and make changes as necessary by committing to your branch and pushing it. You might need to [rebase your changes](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) if another pull request creates conflicts.
 10. That's it! Rejoice that you've helped make Mattermost better.
 
 ### Useful Server Makefile Commands


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

The web app workflow document already has a step for running `make i18n-extract` when adding/modifying the localization strings. This PR adds the same step to the server workflow, as it is also needed.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-23588