### PR TITLE
Webhooks example, fix invalid json

### DIFF
--- a/site/content/integrate/incoming-webhooks/_index.md
+++ b/site/content/integrate/incoming-webhooks/_index.md
@@ -97,8 +97,10 @@ Content-Type: application/json
 {
   "channel": "town-square",
   "username": "Winning-bot",
-  "text": "#### We won a new deal!"
-  "props": "{"card": "Salesforce Opportunity Information:\n\n [Opportunity Name](http://salesforce.com/OPPORTUNITY_ID)\n\n-Salesperson: **Bob McKnight** \n\n Amount: **$300,020.00**"}"
+  "text": "#### We won a new deal!",
+  "props": {
+    "card": "Salesforce Opportunity Information:\n\n [Opportunity Name](http://salesforce.com/OPPORTUNITY_ID)\n\n-Salesperson: **Bob McKnight** \n\n Amount: **$300,020.00**"
+  }
 }
 ```
 


### PR DESCRIPTION
That's it.. just a missing comma and a few extra quotes.
