### PR TITLE
Remove a step to follow style guide from contribution checklist

### DIFF
--- a/site/content/contribute/getting-started/contribution-checklist.md
+++ b/site/content/contribute/getting-started/contribution-checklist.md
@@ -15,19 +15,18 @@ Follow this checklist for submitting a pull request (PR):
  - If you've included your mailing address in the signed [Contributor License Agreement](https://www.mattermost.org/mattermost-contributor-agreement/), you may receive a [Limited Edition Mattermost Mug](https://forum.mattermost.org/t/limited-edition-mattermost-mugs/143) as a thank you gift after your first pull request is merged.
 2. Your ticket is a Help Wanted GitHub issue for the Mattermost project you're contributing to.
     - If not, follow the process [here](/contribute/getting-started/contributions-without-ticket).
-3. Your code follows the [Mattermost Style Guide](http://docs.mattermost.com/developer/style-guide.html).
-4. Your code is thoroughly tested, including appropriate unit tests, [end-to-end tests for webapp](/contribute/webapp/end-to-end-tests/), and manual testing.
-5. If applicable, user interface strings are included in localization files:
+3. Your code is thoroughly tested, including appropriate unit tests, [end-to-end tests for webapp](/contribute/webapp/end-to-end-tests/), and manual testing.
+4. If applicable, user interface strings are included in localization files:
     - [../mattermost-server../en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)
     - [../mattermost-webapp../en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)
     - [../mattermost-mobile../en.json](https://github.com/mattermost/mattermost-mobile/blob/master/assets/base/i18n/en.json)
 
     5.1 In the webapp repository run `make i18n-extract` to generate the new/updated strings.
-6. The PR is submitted against the Mattermost `master` branch from your fork.
-7. The PR title begins with the Jira or GitHub Ticket ID (e.g. `[MM-394]` or `[GH-394]`) and summary template is filled out.
-8. If your PR adds or changes a RESTful API endpoint, please update the [API documentation](https://github.com/mattermost/mattermost-api-reference).
-10. If your PR adds a new plugin API method or hook, please add an example to the [Plugin Starter Template](https://github.com/mattermost/mattermost-plugin-starter-template).
-11. Your PR includes basic documentation about the change/addition you're submitting. View our [guidelines](https://handbook.mattermost.com/operations/operations/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/submitting-documentation-with-your-pr) for more information about submitting documentation and the review process.
+5. The PR is submitted against the Mattermost `master` branch from your fork.
+6. The PR title begins with the Jira or GitHub Ticket ID (e.g. `[MM-394]` or `[GH-394]`) and summary template is filled out.
+7. If your PR adds or changes a RESTful API endpoint, please update the [API documentation](https://github.com/mattermost/mattermost-api-reference).
+8. If your PR adds a new plugin API method or hook, please add an example to the [Plugin Starter Template](https://github.com/mattermost/mattermost-plugin-starter-template).
+9. Your PR includes basic documentation about the change/addition you're submitting. View our [guidelines](https://handbook.mattermost.com/operations/operations/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/submitting-documentation-with-your-pr) for more information about submitting documentation and the review process.
 
 Once submitted, the automated build process must pass in order for the PR to be accepted. Any errors or failures need to be addressed in order for the PR to be accepted. Next, the PR goes through [code review](https://developers.mattermost.com/contribute/getting-started/code-review/). To learn about the review process for each project, read the `CONTRIBUTING.md` file of that GitHub repository. 
 


### PR DESCRIPTION
This style guide page was deleted as the page was outdated. I have also submitted a pull request to update the link in another page this guide was referenced in: https://github.com/avasconcelos114/mattermost-themes/pull/46

I didn't see other references to this page based on Google Analytics.