### PR TITLE
Fix code rendering in plugin docs

### DIFF
--- a/site/content/extend/plugins/webapp/reference.md
+++ b/site/content/extend/plugins/webapp/reference.md
@@ -27,7 +27,9 @@ class PluginClass {
 ```
 
 <a name="registerPlugin"/>
+
 Your plugin should implement this class and register it using the global `registerPlugin` method defined on the window by the webapp:
+
 ```javascript
 window.registerPlugin('myplugin', new PluginClass());
 ```


### PR DESCRIPTION
#### Summary
Both the inline code `registerPlugin` and the code block below need a blank line before to render properly.

Before:
![image](https://user-images.githubusercontent.com/3924815/82437904-81b43980-9a98-11ea-87ef-998283f2df22.png)

After:
![image](https://user-images.githubusercontent.com/3924815/82437929-88db4780-9a98-11ea-8bf2-c169aec41eb8.png)

#### Ticket Link
--