### PR TITLE
Replace esprima with espree

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -4,15 +4,35 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "acorn": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
+    },
+    "acorn-jsx": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
+    },
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    "eslint-visitor-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
+    },
+    "espree": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.0.0.tgz",
+      "integrity": "sha512-/r2XEx5Mw4pgKdyb7GNLQNsu++asx/dltf/CI8RFi9oGHxmQFgvLbc5Op4U6i8Oaj+kdslhJtVlEZeAqH5qOTw==",
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
+      }
     },
     "fs-extra": {
       "version": "2.1.2",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -9,7 +9,7 @@
   "author": "Joram Wilander",
   "license": "MIT",
   "dependencies": {
-    "esprima": "^4.0.0",
+    "espree": "^7.0.0",
     "fs-promise": "^2.0.3",
     "path": "^0.12.7"
   }

--- a/scripts/plugin-jsdocs.js
+++ b/scripts/plugin-jsdocs.js
@@ -4,7 +4,7 @@ const espree = require('espree');
 
 // Parse the registry and extract the class methods, parameters and leading comments.
 const registryContent = fsp.readFileSync(path.join(__dirname, 'mattermost-webapp/plugins/registry.js'), 'utf-8')
-const registryParsed = espree.parse(registryContent, { comment: true, attachComment: true, sourceType: 'module', ecmaVersion: 10 });
+const registryParsed = espree.parse(registryContent, { comment: true, loc: true, sourceType: 'module', ecmaVersion: 10 });
 
 const pluginRegistryClassMethods = registryParsed.body.find(statement =>
     statement.type === "ExportDefaultDeclaration" &&
@@ -12,15 +12,51 @@ const pluginRegistryClassMethods = registryParsed.body.find(statement =>
 ).declaration.body.body.filter(statement =>
     statement.type === "MethodDefinition" &&
     statement.key.name !== "constructor"
-).map(statement => ({
-    Name: statement.key.name,
-    Parameters: statement.value.params.map(param => param.name),
-    Comments: statement.leadingComments ? statement.leadingComments.map(comment => comment.value.trim()) : [],
-}));
+)
+
+// Group all adjacent comments in commentBlocks.
+let commentBlocks = [];
+let lastLine = -2;
+let currentBlock = [];
+registryParsed.comments.forEach(comment => {
+    if (comment.loc.start.line === (lastLine + 1)) {
+        currentBlock.push(comment);
+    } else {
+        currentBlock = [comment];
+        commentBlocks.push(currentBlock);
+    }
+
+    lastLine = comment.loc.start.line;
+});
+
+// Given a comment block, compute the number of its last line.
+const blockLastLine = (commentBlock) => {
+    const mapped = commentBlock.map(c => c.loc.start.line);
+    return Math.max(...mapped);
+};
+
+// Generate a dictionary mapping every line with a preceding comment block to
+// that specific block.
+const lineToPrecedingBlock = {};
+commentBlocks.forEach(block => {
+    const line = blockLastLine(block) + 1;
+    lineToPrecedingBlock[line] = block.map(comment => comment.value);
+});
+
+// For every method in the plugin registry, build an object with its name,
+// its parameters and its preceding comment block.
+const methodsOutput = pluginRegistryClassMethods.map((statement) => {
+    const commentBlock = lineToPrecedingBlock[statement.loc.start.line];
+    return {
+        Name: statement.key.name,
+        Parameters: statement.value.params.map(param => param.name),
+        Comments: commentBlock ? commentBlock : [],
+    }
+});
 
 output = {
     Interface: {
-        Methods: pluginRegistryClassMethods,
+        Methods: methodsOutput,
     },
 };
 

--- a/scripts/plugin-jsdocs.js
+++ b/scripts/plugin-jsdocs.js
@@ -1,10 +1,10 @@
 const path = require('path');
 const fsp = require('fs-promise');
-const esprima = require('esprima');
+const espree = require('espree');
 
 // Parse the registry and extract the class methods, parameters and leading comments.
 const registryContent = fsp.readFileSync(path.join(__dirname, 'mattermost-webapp/plugins/registry.js'), 'utf-8')
-const registryParsed = esprima.parseModule(registryContent, { comment: true, attachComment: true });
+const registryParsed = espree.parseModule(registryContent, { comment: true, attachComment: true });
 
 const pluginRegistryClassMethods = registryParsed.body.find(statement =>
     statement.type === "ExportDefaultDeclaration" &&

--- a/scripts/plugin-jsdocs.js
+++ b/scripts/plugin-jsdocs.js
@@ -4,7 +4,7 @@ const espree = require('espree');
 
 // Parse the registry and extract the class methods, parameters and leading comments.
 const registryContent = fsp.readFileSync(path.join(__dirname, 'mattermost-webapp/plugins/registry.js'), 'utf-8')
-const registryParsed = espree.parseModule(registryContent, { comment: true, attachComment: true });
+const registryParsed = espree.parse(registryContent, { comment: true, attachComment: true, sourceType: 'module', ecmaVersion: 10 });
 
 const pluginRegistryClassMethods = registryParsed.body.find(statement =>
     statement.type === "ExportDefaultDeclaration" &&

--- a/site/layouts/shortcodes/pluginjsdocs.html
+++ b/site/layouts/shortcodes/pluginjsdocs.html
@@ -29,7 +29,7 @@
 {{ define "JSFunctionSignatureHTML" }}
     <pre><code>/**
 {{- range .Comments }}
-    * {{ . }}
+    *{{ . }}
 {{- end }}
 */
 {{.Name }}({{ template "JSFieldsString" .Parameters }})</code></pre>


### PR DESCRIPTION
#### Summary
@metanerd investigated the latest failed build in master and narrowed it down to this change: https://github.com/mattermost/mattermost-webapp/commit/397e4b65a610cfc81ab8076dbf9348c71d4d4872#diff-99e11b3b61425aff9ef2e561dd706b2cR600

After some more investigation, it looks like [esprima](https://github.com/jquery/esprima) does not recognize the [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) in its latest release, even if they have it on master: https://github.com/jquery/esprima/issues/1927

This PR replaces esprima with [espree](https://github.com/eslint/espree), a more up-to-date fork.

See a bit more of context in this thread in Mattermost: https://community-daily.mattermost.com/core/pl/4tewph9mjpyfxywr9ygyg8syec

#### Ticket Link
--

