### PR TITLE
Accurate path for exposing System Console settings

### DIFF
--- a/site/content/contribute/server/system_console.md
+++ b/site/content/contribute/server/system_console.md
@@ -12,7 +12,7 @@ In order to add fields to the configuration, you need to modify `model/config.go
 
 ### Exposing settings in the System Console
 
-To expose the newly added field in the System Console, you need to add that same setting to the `AdminDefinition` JS object in `components/admin_console/admin_definition.jsx`. This object defines most of the settings in the System Console.
+To expose the newly added field in the System Console, you need to add that same setting to the `AdminDefinition` JS object in `mattermost-webapp/components/admin_console/admin_definition.jsx`. This object defines most of the settings in the System Console.
 
 
 ### Making settings available for non-admin users

--- a/site/content/contribute/server/system_console.md
+++ b/site/content/contribute/server/system_console.md
@@ -12,7 +12,7 @@ In order to add fields to the configuration, you need to modify `model/config.go
 
 ### Exposing settings in the System Console
 
-To expose the newly added field in the System Console, you need to add that same setting to the `AdminDefinition` JS object in `mattermost-webapp/components/admin_console/admin_definition.jsx`. This object defines most of the settings in the System Console.
+To expose the newly-added field in the System Console, you need to add that same setting to the `AdminDefinition` JS object in `mattermost-webapp/components/admin_console/admin_definition.jsx`. This object defines most of the settings in the System Console.
 
 
 ### Making settings available for non-admin users


### PR DESCRIPTION
This adds the `mattermost-webapp`  directory prefix to the documented line. A new person might look in the `mattermost-server` directory for the path and will lose time looking for it.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

