### PR TITLE
#634 Add the user to the `docker` group

### DIFF
--- a/site/content/contribute/server/developer-setup/centos.md
+++ b/site/content/contribute/server/developer-setup/centos.md
@@ -58,6 +58,12 @@
     {username}  hard  nofile  8096
     ```
 
+6. Add your user to the `docker` group, replacing `{username}` with your username:
+
+    ```sh
+    sudo usermod -aG docker {username}
+    ```
+
 6. Log out and log back in to effect the changes above.
 
 7. Fork https://github.com/mattermost/mattermost-server.

--- a/site/content/contribute/server/developer-setup/centos.md
+++ b/site/content/contribute/server/developer-setup/centos.md
@@ -64,17 +64,17 @@
     sudo usermod -aG docker {username}
     ```
 
-6. Log out and log back in to effect the changes above.
+7. Log out and log back in to effect the changes above.
 
-7. Fork https://github.com/mattermost/mattermost-server.
+8. Fork https://github.com/mattermost/mattermost-server.
 
-8. Clone the Mattermost source code from your fork:
+9. Clone the Mattermost source code from your fork:
 
     ```sh
     git clone https://github.com/YOUR_GITHUB_USERNAME/mattermost-server.git
     ```
 
-9. Start the server and test your environment:
+10. Start the server and test your environment:
 
     ```sh
     cd mattermost-server


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adds a step for the user to add themselves to the `docker` group in the Server Developer Setup documentation for Fedora / CentOS.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://github.com/mattermost/mattermost-developer-documentation/issues/634

