### PR TITLE
Make the `dist` directory first

### DIFF
--- a/site/content/contribute/webapp/developer-setup.md
+++ b/site/content/contribute/webapp/developer-setup.md
@@ -32,6 +32,7 @@ Set up your development environment for building, running, and testing the Matte
 5. Link the `client` directory in your server with the `dist` directory in your webapp:
 
     ```sh
+    mkdir -p mattermost-webapp/dist
     cd mattermost-server
     ln -nfs ../mattermost-webapp/dist client
     cd ..


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The `mattermost-webapp/dist` directory doesn't exist in our clone. We should create it first, then link to it in order to avoid confusion.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

(None)