### PR TITLE
Fix "We're hiring" banner's close button

### DIFF
--- a/site/layouts/partials/notification.html
+++ b/site/layouts/partials/notification.html
@@ -1,7 +1,7 @@
 {{ if .Site.Params.notification.enable }}
 <div class='notification-bar sticky-top'>
     <div class="notification-bar__content">
-        <a href="#" class="notification-bar__close">
+        <a class="notification-bar__close">
             <span aria-hidden="true">×</span>
         </a>
         <a href="{{ .Site.Params.notification.url | absURL }}">

--- a/site/static/css/bar.css
+++ b/site/static/css/bar.css
@@ -32,6 +32,7 @@
     font-size: 36px;
     font-weight: 300;
     position: absolute;
+    cursor: pointer;
     right: 0px;
     opacity: .3;
     top: 0;


### PR DESCRIPTION
#### Summary

With this PR, clicking the banner's X no longer scrolls to the top of the page

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-developer-documentation/issues/679