### PR TITLE
Add a point about running storybook for e2e tests.

### DIFF
--- a/site/content/contribute/webapp/end-to-end-tests.md
+++ b/site/content/contribute/webapp/end-to-end-tests.md
@@ -18,6 +18,7 @@ Not familiar with Cypress? Here is some documentation that will help you get sta
 1.  Run a local server instance by initiating `make run` to the mattermost-server folder. Confirm that the instance has started successfully.
     - Run `make test-data` to preload your server instance with initial seed data.
     - Each test case should handle the required system or user settings, but in case you encounter an unexpected error while testing, you may want to run the server with default config based on `mattermost-server/config/default.json`.
+    - In another terminal, run `npm run storybook` in the `mattermost-webapp` directory. This is required for the Cypress tests which run against the Storybook widgets to pass.
 2.  Change directory to `mattermost-webapp/e2e`, and install npm dependencies by running `npm i`.
     - Initiate `npm run cypress:run` in the command line to start full E2E testing. This excludes the specs in the `/cypress/integration/enterprise` folder as they require an Enterprise license to run successfully.
     - Initiate `npm run cypress:open` in the command line to start partial testing depending on which spec is selected via Cypress's desktop app.

--- a/site/content/contribute/webapp/end-to-end-tests.md
+++ b/site/content/contribute/webapp/end-to-end-tests.md
@@ -18,7 +18,7 @@ Not familiar with Cypress? Here is some documentation that will help you get sta
 1.  Run a local server instance by initiating `make run` to the mattermost-server folder. Confirm that the instance has started successfully.
     - Run `make test-data` to preload your server instance with initial seed data.
     - Each test case should handle the required system or user settings, but in case you encounter an unexpected error while testing, you may want to run the server with default config based on `mattermost-server/config/default.json`.
-    - In another terminal, run `npm run storybook` in the `mattermost-webapp` directory. This is required for the Cypress tests which run against the Storybook widgets to pass.
+    - In another terminal, in the `mattermost-webapp` directory, run `npm run storybook`. This is required for the Cypress tests which run against the Storybook widgets to pass.
 2.  Change directory to `mattermost-webapp/e2e`, and install npm dependencies by running `npm i`.
     - Initiate `npm run cypress:run` in the command line to start full E2E testing. This excludes the specs in the `/cypress/integration/enterprise` folder as they require an Enterprise license to run successfully.
     - Initiate `npm run cypress:open` in the command line to start partial testing depending on which spec is selected via Cypress's desktop app.

--- a/site/content/contribute/webapp/end-to-end-tests.md
+++ b/site/content/contribute/webapp/end-to-end-tests.md
@@ -15,7 +15,7 @@ Not familiar with Cypress? Here is some documentation that will help you get sta
 ## Quick Overview on How to Run E2E Testing
 
 ### On Your Local Development Machine
-1.  Launch a local Mattermost instance by running `make run` in the mattermost-server directory. Confirm that the Mattermost instance has started successfully.
+1.  Launch a local Mattermost instance by running `make run` in the `mattermost-server` directory. Confirm that the Mattermost instance has started successfully.
     - Run `make test-data` to preload your server instance with initial seed data.
     - Each test case should handle the required system or user settings, but in case you encounter an unexpected error while testing, you may want to run the server with default config based on `mattermost-server/config/default.json`.
     - In another terminal, in the `mattermost-webapp` directory, run `npm run storybook`. This is required for the Cypress tests which run against the Storybook widgets to pass.

--- a/site/content/contribute/webapp/end-to-end-tests.md
+++ b/site/content/contribute/webapp/end-to-end-tests.md
@@ -15,7 +15,7 @@ Not familiar with Cypress? Here is some documentation that will help you get sta
 ## Quick Overview on How to Run E2E Testing
 
 ### On Your Local Development Machine
-1.  Run a local server instance by initiating `make run` to the mattermost-server folder. Confirm that the instance has started successfully.
+1.  Launch a local Mattermost instance by running `make run` in the mattermost-server directory. Confirm that the Mattermost instance has started successfully.
     - Run `make test-data` to preload your server instance with initial seed data.
     - Each test case should handle the required system or user settings, but in case you encounter an unexpected error while testing, you may want to run the server with default config based on `mattermost-server/config/default.json`.
     - In another terminal, in the `mattermost-webapp` directory, run `npm run storybook`. This is required for the Cypress tests which run against the Storybook widgets to pass.


### PR DESCRIPTION
#### Summary
Add missing step from cypress guide about running the storybook.