### PR TITLE
Correcting info on starting the webserver for the developer version

### DIFF
--- a/site/content/contribute/webapp/developer-setup.md
+++ b/site/content/contribute/webapp/developer-setup.md
@@ -44,9 +44,11 @@ Set up your development environment for building, running, and testing the Matte
     cd mattermost-webapp
     make test
     ```
-7. When tests pass, run the app: 
+7. When tests pass, run the app:
 
      ```sh
+    cd ..
+    cd mattermost-server 
     make run
     ```
 


### PR DESCRIPTION
Correcting an issue in the developer setup instructions. The original instruction said to run `make run` in the mattermost-webapp directory, but it needs to be run in mattermost-server