### PR TITLE
Add website footer to blog section

### DIFF
--- a/site/layouts/blog/list.html
+++ b/site/layouts/blog/list.html
@@ -28,5 +28,6 @@
             </div>
         </div>
     </div>
+    {{ partial "footer.html" .}}
 </body>
 </html>

--- a/site/layouts/blog/single.html
+++ b/site/layouts/blog/single.html
@@ -55,7 +55,7 @@
 {{ if .Params.toc }}
                 <h6>Table Of Contents</h6>
                     {{ .TableOfContents }}
-{{ end }}                    
+{{ end }}
                     {{ partial "series_link.html" . }}
 
                     <h6>Other Posts</h6>
@@ -70,6 +70,7 @@
             </div>
         </div>
     </div>
+    {{ partial "footer.html" .}}
 </body>
 
 </html>


### PR DESCRIPTION
The pull-request adds the footer used on multiple pages across the site to the blog section of the website

It also resolves issue #685 