### PR TITLE
[GH-686] sorting blog posts by date

### DIFF
--- a/site/layouts/blog/list.html
+++ b/site/layouts/blog/list.html
@@ -14,7 +14,7 @@
         <div class="row">
             <div class="col-md-9 doc-content">
                 <h3>Mattermost Developer Blog</h3>
-                {{ range (.Paginate .Data.Pages).Pages }}
+                {{ range (.Paginate .Data.Pages).Pages.ByDate.Reverse }}
                     {{ .Render "summary" }}
                 {{ end }}
                 <div class="blog-pagination">


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Blog posts are not showing in order as mentioned in #686

To fix this, we need to make a small change in `site/layouts/blog/list.html` to add sorting.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-developer-documentation/issues/686

Hope this helps and stay safe!

Happy Hactoberfest2020 :fireworks: 
Hiren