### PR TITLE
change `npm -g install react-native-cli` to `sudo npm -g install react-native-cli`

### DIFF
--- a/site/content/contribute/mobile/developer-setup/_index.md
+++ b/site/content/contribute/mobile/developer-setup/_index.md
@@ -75,7 +75,7 @@ The minimum required version is 4.9.0.
 #### Install `react-native-cli` tools
 
 ```sh
-$ npm -g install react-native-cli
+$ sudo npm -g install react-native-cli
 ```
 #### Install Ruby
 ##### Windows 10


### PR DESCRIPTION
#### Summary
changed `npm -g install react-native-cli` to `sudo npm -g install react-native-cli` in `site/contribute/mobile/developer-setup/_index.md` line 78

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-developer-documentation/issues/732


