### PR TITLE
Fixing links to download app signing scripts

### DIFF
--- a/site/content/contribute/mobile/unsigned/android.md
+++ b/site/content/contribute/mobile/unsigned/android.md
@@ -13,7 +13,7 @@ With every Mattermost mobile app release, we publish the Android unsigned apk in
 2. [XMLStarlet](http://xmlstar.sourceforge.net/doc/UG/xmlstarlet-ug.html) is a set of command line utilities (tools) which can be used to transform, query, validate, and edit XML documents and files using a simple set of shell commands in the same way it is done for plain text files using UNIX `grep`, `sed`, `awk`, `diff`, `patch`, `join`, etc., commands.
 3. [JQ](https://stedolan.github.io/jq/) is like `sed` for JSON data - you can use it to slice, filter, map, and transform structured data with the same ease that `sed`, `awk`, and `grep` let you work with text.
 4. Android SDK as described in the [Developer Setup](/contribute/mobile/developer-setup/#additional-setup-for-android).
-5. Setup keys and Google Services as described in steps 2, 3, 4 & 6 of the [Build your own App guide](/contribute/mobile/build-your-own/android/#build-preparations).
+5. Set up keys and Google Services as described in steps 2, 3, 4, and 6 of the [Build your own App guide](/contribute/mobile/build-your-own/android/#build-preparations).
 6. [sign-android](/scripts/sign-android) script to sign the Android app.
 
 #### Signing Tool

--- a/site/content/contribute/mobile/unsigned/android.md
+++ b/site/content/contribute/mobile/unsigned/android.md
@@ -44,7 +44,7 @@ Options:
 
 #### Sign the Mattermost Android app
 
-Now that all requirements are met, it's time to sign the Mattermost app for Android. Most of the options of the signing tool are optional but you should really be using your own `package identifier`, `google services settings` and maybe change the `display name`.
+Now that all requirements are met, it's time to sign the Mattermost app for Android. Most of the options of the signing tool are optional but you should use your own `package identifier`, `google services settings` and change the `display name`.
 
 * Create a folder that will serve as your working directory to store all the needed files.
 * Download the [sign-android](/scripts/sign-android) script and save it in your working directory.

--- a/site/content/contribute/mobile/unsigned/android.md
+++ b/site/content/contribute/mobile/unsigned/android.md
@@ -14,7 +14,7 @@ With every Mattermost mobile app release, we publish the Android unsigned apk in
 3. [JQ](https://stedolan.github.io/jq/) is like sed for JSON data - you can use it to slice, filter, map, and transform structured data with the same ease that `sed`, `awk`, and `grep` let you work with text.
 4. Android SDK as described in the [Developer Setup](/contribute/mobile/developer-setup/#additional-setup-for-android).
 5. Setup keys and Google Services as described in steps 2, 3, 4 & 6 of the [Build your own App guide](/contribute/mobile/build-your-own/android/#build-preparations).
-6. `sign-android` script to sign the Android app.
+6. [sign-android](/scripts/sign-android) script to sign the Android app.
 
 #### Signing Tool
 
@@ -47,7 +47,7 @@ Options:
 Now that all requirements are met, it's time to sign the Mattermost app for Android. Most of the options of the signing tool are optional but you should really be using your own `package identifier`, `google services settings` and maybe change the `display name`.
 
 * Create a folder that will serve as your working directory to store all the needed files.
-* Download the [sign-android](/scripts/sign-android/) script and save it in your working directory.
+* Download the [sign-android](/scripts/sign-android) script and save it in your working directory.
 * Download the [Android unsigned build](https://github.com/mattermost/mattermost-mobile/releases) and save it in your working directory.
 * Open a terminal to your working directory and make sure the `sign-android` script it is executable.
 

--- a/site/content/contribute/mobile/unsigned/android.md
+++ b/site/content/contribute/mobile/unsigned/android.md
@@ -11,7 +11,7 @@ With every Mattermost mobile app release, we publish the Android unsigned apk in
 
 1. [Apktool](https://ibotpeaches.github.io/Apktool/) is a tool for reverse engineering Android apk files.
 2. [XMLStarlet](http://xmlstar.sourceforge.net/doc/UG/xmlstarlet-ug.html) is a set of command line utilities (tools) which can be used to transform, query, validate, and edit XML documents and files using a simple set of shell commands in the same way it is done for plain text files using UNIX `grep`, `sed`, `awk`, `diff`, `patch`, `join`, etc., commands.
-3. [JQ](https://stedolan.github.io/jq/) is like sed for JSON data - you can use it to slice, filter, map, and transform structured data with the same ease that `sed`, `awk`, and `grep` let you work with text.
+3. [JQ](https://stedolan.github.io/jq/) is like `sed` for JSON data - you can use it to slice, filter, map, and transform structured data with the same ease that `sed`, `awk`, and `grep` let you work with text.
 4. Android SDK as described in the [Developer Setup](/contribute/mobile/developer-setup/#additional-setup-for-android).
 5. Setup keys and Google Services as described in steps 2, 3, 4 & 6 of the [Build your own App guide](/contribute/mobile/build-your-own/android/#build-preparations).
 6. [sign-android](/scripts/sign-android) script to sign the Android app.

--- a/site/content/contribute/mobile/unsigned/android.md
+++ b/site/content/contribute/mobile/unsigned/android.md
@@ -44,7 +44,7 @@ Options:
 
 #### Sign the Mattermost Android app
 
-Now that all requirements are met, it's time to sign the Mattermost app for Android. Most of the options of the signing tool are optional but you should use your own `package identifier`, `google services settings` and change the `display name`.
+Now that all requirements are met, it's time to sign the Mattermost app for Android. Most of the options of the signing tool are optional but you should use your own `package identifier`, `google services settings`, and change the `display name`.
 
 * Create a folder that will serve as your working directory to store all the needed files.
 * Download the [sign-android](/scripts/sign-android) script and save it in your working directory.

--- a/site/content/contribute/mobile/unsigned/android.md
+++ b/site/content/contribute/mobile/unsigned/android.md
@@ -49,7 +49,7 @@ Now that all requirements are met, it's time to sign the Mattermost app for Andr
 * Create a folder that will serve as your working directory to store all the needed files.
 * Download the [sign-android](/scripts/sign-android) script and save it in your working directory.
 * Download the [Android unsigned build](https://github.com/mattermost/mattermost-mobile/releases) and save it in your working directory.
-* Open a terminal to your working directory and make sure the `sign-android` script it is executable.
+* Open a terminal to your working directory and make sure the `sign-android` script is executable.
 
 ```bash
 $ ls -la

--- a/site/content/contribute/mobile/unsigned/ios.md
+++ b/site/content/contribute/mobile/unsigned/ios.md
@@ -13,7 +13,7 @@ With every Mattermost mobile app release, we publish the iOS unsigned ipa in in 
 2. Install the Xcode command line tools:
 	```bash
 	$ xcode-select --install
-3. Set up your Certificate and Provisioning profiles as described in steps 1 & 2 for [Run on iOS Devices](/contribute/mobile/developer-setup/run/#run-on-ios-devices) in the Developer Setup.
+3. Set up your Certificate and Provisioning profiles as described in steps 1 and 2 for [Run on iOS Devices](/contribute/mobile/developer-setup/run/#run-on-ios-devices) in the Developer Setup.
 4. [sign-ios](/scripts/sign-ios) script to sign the iOS app.
 
 #### Signing Tool

--- a/site/content/contribute/mobile/unsigned/ios.md
+++ b/site/content/contribute/mobile/unsigned/ios.md
@@ -14,7 +14,7 @@ With every Mattermost mobile app release, we publish the iOS unsigned ipa in in 
 	```bash
 	$ xcode-select --install
 3. Set up your Certificate and Provisioning profiles as described in steps 1 & 2 for [Run on iOS Devices](/contribute/mobile/developer-setup/run/#run-on-ios-devices) in the Developer Setup.
-4. `sign-ios` script to sign the iOS app.
+4. [sign-ios](/scripts/sign-ios) script to sign the iOS app.
 
 #### Signing Tool
 
@@ -60,7 +60,7 @@ and you should be using your own `provisioning profiles`, `certificate`, also yo
 * Download your **Apple Distribution certificate** from the [Apple Developer portal](https://developer.apple.com/account/resources/certificates/list) and save it in your working directory.
 * Install the previously downloaded certificate into your macOS Keychain. [Learn more](https://developer.apple.com/support/certificates).
 * Download your **Provisioning profiles** from the [Apple Developer portal](https://developer.apple.com/account/resources/profiles/list) and save it in your working directory.
-* Download the [sign-ios](/scripts/sign-ios/) script and save it in your working directory.
+* Download the [sign-ios](/scripts/sign-ios) script and save it in your working directory.
 * Download the [iOS unsigned build](https://github.com/mattermost/mattermost-mobile/releases) and save it in your working directory.
 * Open a terminal to your working directory and make sure the `sign-ios` script it is executable.
 

--- a/site/content/contribute/mobile/unsigned/ios.md
+++ b/site/content/contribute/mobile/unsigned/ios.md
@@ -62,7 +62,7 @@ and you should be using your own `provisioning profiles`, `certificate`, also yo
 * Download your **Provisioning profiles** from the [Apple Developer portal](https://developer.apple.com/account/resources/profiles/list) and save it in your working directory.
 * Download the [sign-ios](/scripts/sign-ios) script and save it in your working directory.
 * Download the [iOS unsigned build](https://github.com/mattermost/mattermost-mobile/releases) and save it in your working directory.
-* Open a terminal to your working directory and make sure the `sign-ios` script it is executable.
+* Open a terminal to your working directory and make sure the `sign-ios` script is executable.
 
 ```bash
 $ ls -la
@@ -90,4 +90,3 @@ Once the code sign is complete you should have a signed IPA in the working direc
 The app name can be anything but be sure to use double quotes if the name includes white spaces. The name of the `certificate` should match the name in the macOS Keychain.
 
 ---
-


### PR DESCRIPTION
The links to scripts that are needed in these docs were not working correctly.  There was an extra `/` appended in the url. Updating this