### PR TITLE
Modified `smali` related paths based apktool change

### DIFF
--- a/site/static/scripts/sign-android
+++ b/site/static/scripts/sign-android
@@ -58,7 +58,7 @@ fi
 
 ANDROID="${ANDROID_HOME:-$ANDROID_SDK_ROOT}"
 
-if [ -z $ANDROID ]; then 
+if [ -z $ANDROID ]; then
     echo ""
     echo "\$ANDROID_HOME or \$ANDROID_SDK_ROOT environment variable not set."
     echo "More info at https://developer.android.com/studio/command-line/variables#android_sdk_root"
@@ -143,12 +143,12 @@ if [ "$PACKAGE_ID" != "" ]; then
     echo "Replacing package ID"
     IFS='.' read -r -a DIRS <<< "$PACKAGE_ID"
     PACKAGE_DIR=$( IFS=$'/'; echo "${DIRS[*]}" )
-    mkdir -p "$EXTRACT_PATH/smali/$PACKAGE_DIR"
-    SRC="$EXTRACT_PATH/smali/com/mattermost/rnbeta/*.*"
-    DEST="$EXTRACT_PATH/smali/$PACKAGE_DIR"
-    mv $SRC $DEST
-    find "$EXTRACT_PATH/smali/com/mattermost" -type f -exec sed -i '' -e "s~Lcom/mattermost/rnbeta~L$PACKAGE_DIR~g" {} \;
+    mkdir -p "$EXTRACT_PATH/smali_classes2/$PACKAGE_DIR"
+    SRC="$EXTRACT_PATH/smali_classes2/com/mattermost/rnbeta/*.*"
+    DEST="$EXTRACT_PATH/smali_classes2/$PACKAGE_DIR"
+    find "$EXTRACT_PATH/smali_classes2/com/mattermost" -type f -exec sed -i '' -e "s~Lcom/mattermost/rnbeta~L$PACKAGE_DIR~g" {} \;
     sed -i '' -e "s/com.mattermost.rnbeta/$PACKAGE_ID/g" "$EXTRACT_PATH/AndroidManifest.xml"
+    mv $SRC $DEST
 
     if [ "$GOOGLE_SERVICES_PATH" != "" ]; then
         echo "Replacing Google Services values"


### PR DESCRIPTION
apktool seems to unpack the apk files to different paths.  Admittedly I don't understand the inner workings of whats happening, but I noticed the unpacked apk had smali files at a different path than what was expected by the `sign-android` script.

My `apktool` version (in case its relevant):
```
Apktool v2.5.0 - a tool for reengineering Android apk files
with smali v2.4.0 and baksmali v2.4.0
```
I also shifted `mv $SRC $DEST` down a few lines as this seemed to be done too early for the `sed` modifications to apply.