### PR TITLE
[GH-722] - Fix content wider than screen on mobile

### DIFF
--- a/site/static/css/styles.css
+++ b/site/static/css/styles.css
@@ -3081,10 +3081,15 @@ body {
 
 a {
     color: #186CDA;
+    word-break: break-word;
 }
 
 a:hover {
     text-decoration: none;
+}
+
+code {
+    word-break: break-word;
 }
 
 .container-fluid {
@@ -3402,7 +3407,7 @@ table>tbody>tr:nth-of-type(odd) {
 }
 
 .doc-content .edit-github {
-    padding-top: 0.9rem;
+    padding: 0.9rem;
 }
 
 .doc-content .doc-title {
@@ -3580,6 +3585,51 @@ table>tbody>tr:nth-of-type(odd) {
     height: 60px;
 }
 
+.steps-row {
+    display: flex;
+    margin: 3rem 0;
+}
+
+.steps-number {
+    width: 50px;
+    height: 50px;
+    border-radius: 25px;
+    border: 1px solid #007bff;
+    display: flex;
+    flex-shrink: 0;
+    justify-content: center;
+    align-items: center;
+    margin-right: 35px;
+    color: #007bff;
+}
+
+.steps-header {
+    margin-right: 10px;
+    margin-bottom: 10px;
+}
+
+.steps-row .content {
+    margin-right: 10px;
+}
+
+.alert {
+    font-size: 95%;
+}
+
+blockquote {
+    margin: 0 0.5rem;
+    padding: 0 0.5rem;
+    border-left: 1px solid grey;
+}
+
+pre {
+    padding: 0.5rem;
+}
+
+ol > li + li {
+    margin-top: 1rem;
+}
+
 @media (max-width: 992px) {
     .sidebar__menu-toggle {
         display: block;
@@ -3644,35 +3694,7 @@ table>tbody>tr:nth-of-type(odd) {
     .homepage-boxes {
         margin-top: -13em;
     }
-}
 
-.steps-row {
-    display: flex;
-    margin: 3rem 0;
-}
-
-.steps-number {
-    width: 50px;
-    height: 50px;
-    border-radius: 25px;
-    border: 1px solid #007bff;
-    display: flex;
-    flex-shrink: 0;
-    justify-content: center;
-    align-items: center;
-    margin-right: 35px;
-    color: #007bff;
-}
-
-.steps-header {
-    margin-bottom: 10px;
-}
-
-.alert {
-    font-size: 95%;
-}
-
-@media (max-width: 768px) {
     .blog-list .blog-item__date {
         float: none;
         display: block;
@@ -3680,16 +3702,20 @@ table>tbody>tr:nth-of-type(odd) {
     }
 }
 
-blockquote {
-    margin: 0 0.5rem;
-    padding: 0 0.5rem;
-    border-left: 1px solid grey;
+@media (max-width: 576px) {
+    .steps-number {
+        margin-right: 20px;
+    }
+    .sidebar+.doc-content {
+        padding-left: 40px;
+    }
 }
 
-pre {
-    padding: 0.5rem;
-}
-
-ol > li + li {
-    margin-top: 1rem;
+@media (max-width: 400px) {
+    .sidebar+.doc-content {
+        padding-left: 30px;
+    }
+    .sidebar {
+        margin: 50px 30px 0;
+    }
 }

--- a/site/static/css/styles.css
+++ b/site/static/css/styles.css
@@ -3429,10 +3429,6 @@ table>tbody>tr:nth-of-type(odd) {
     padding: 14px;
 }
 
-.doc-content table {
-    .table-striped;
-}
-
 .homepage .homepage__bg {
     -moz-transform: skew(0deg, -5deg);
     -ms-transform: skew(0deg, -5deg);


### PR DESCRIPTION
### Summary
- prevented content from overflowing the screen on small-sized mobile phone devices, such as iPhone 5/SE
- deleted unused code block with css class `.table-striped` and no specified styles

**Note:** I have moved all the css media queries to the end of the file to prevent styles overwrite which is why there seem to be so many changes in the diff.

### Ticket Link

Fixes https://github.com/mattermost/mattermost-developer-documentation/issues/722

### Screenshots

Here is an example of the proposed changes, shown on iPhone 5:

**Proposed fix** (left) vs. **Current state** (right)

![matter1](https://user-images.githubusercontent.com/46979603/107126814-64d3c680-68b2-11eb-82bc-1f2cd180d2b0.jpg)

![matter2](https://user-images.githubusercontent.com/46979603/107126854-9ba9dc80-68b2-11eb-823d-76bff97653bc.jpg)

![matter3](https://user-images.githubusercontent.com/46979603/107126863-a4021780-68b2-11eb-8e9b-e4df7877aba9.jpg)
