### PR TITLE
H1 title system for consistent rendering of h1 title tags

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -143,86 +143,107 @@ pygmentsStyle = "manni"
   [params.indexes]
     [[params.indexes.item]]
       relPermaLink = "/blog/"
+      heading = "The Mattermost Developer Blog"
       description = "Read the latest technical how-tos and articles from the Mattermost team and community on the Mattermost Developer Blog."
 
     [[params.indexes.item]]
       relPermaLink = "/contribute/"
+      heading = "How to Contribute to Mattermost"
       description = "Find out how to contribute to the Mattermost open source project and the various ways to get involved."
 
     [[params.indexes.item]]
+      relPermaLink = "/extend/"
+      heading = "How to Extend Mattermost"
+      description = "Learn about how you can extend Mattermost to customize it for your unique purposes."
+
+    [[params.indexes.item]]
       relPermaLink = "/integrate/"
+      heading = "Learn about Integrations at Mattermost"
       description = "Mattermost integrates with a number of tools your DevOps team uses every day."
 
     [[params.indexes.item]]
       relPermaLink = "/internal/"
+      heading = "Internal Mattermost Documentation"
       description = "This is a place for documentation used internally by Mattermost employees. If you don't work at Mattermost, this might not be helpful."
-
-    [[params.indexes.item]]
-      relPermaLink = "/extend/"
-      description = "Learn about how you can extend Mattermost to customize it for your unique purposes."
 
   # Categories Meta (Taxonomies appearing under /categories/)
   [params.categories]
+    heading = "Content Categories at Mattermost"
     description = "Looking to learn about open source, DevOps, and Mattermost? Browse this list of categories to find content that interests you."
 
     [[params.categories.item]]
       term = "announcement"
+      heading = "Content about Announcements at Mattermost"
       description = "This repository includes announcements related to the Mattermost open source project."
 
     [[params.categories.item]]
       term = "announcements"
+      heading = "Content about Announcements at Mattermost"
       description = "Check out this repository to read Mattermost announcements and keep up with company developments."
 
     [[params.categories.item]]
       term = "contributing"
+      heading = "Content about Contributing at Mattermost"
       description = "Thinking about getting involved with Mattermost? Read some tips on contributing effectively."
 
     [[params.categories.item]]
       term = "devops"
+      heading = "Content about DevOps at Mattermost"
       description = "Mattermost is designed for DevOps. Learn more about how development teams can use Mattermost to improve their DevOps workflow and processes."
 
     [[params.categories.item]]
       term = "git"
+      heading = "Content about Git at Mattermost"
       description = "Check out this repository to find out information about Git and how Mattermost uses it."
 
     [[params.categories.item]]
       term = "Go"
+      heading = "Content about Go at Mattermost"
       description = "Interested in Go? We are too. Learn about how Mattermost uses Go to build powerful software."
 
     [[params.categories.item]]
       term = "kubernetes"
+      heading = "Content about Kubernetes at Mattermost"
       description = "Are you looking to learn more about Kubernetes? See how Mattermost uses Kubernetes to build apps."
 
     [[params.categories.item]]
       term = "linting"
+      heading = "Content about Linting at Mattermost"
       description = "Interested in learning more about linting? Find out how we use linting at Mattermost."
 
     [[params.categories.item]]
       term = "markdown"
+      heading = "Content about Markdown"
       description = "Markdown makes formatting text easy, which enables you to communicate more effectively online."
 
     [[params.categories.item]]
       term = "opensource"
+      heading = "Content about Open Source at Mattermost"
       description = "This repository includes articles about open source technology and open source communities."
 
     [[params.categories.item]]
       term = "performance"
+      heading = "Content about Peformance at Mattermost"
       description = "Looking to improve the performance of your applications? Learn how we approach performance at Mattermost."
 
     [[params.categories.item]]
       term = "plugins"
+      heading = "Content about Plugins at Mattermost"
       description = "Want to learn about plugins in Mattermost? Check out this repository to learn more."
 
     [[params.categories.item]]
       term = "security"
+      heading = "Content about Security at Mattermost"
       description = "Read these articles to learn about how Mattermost approaches security and other related security content."
 
     [[params.categories.item]]
       term = "testing"
+      heading = "Content about Testing at Mattermost"
       description = "Read about how the Mattermost team uses testing to ensure apps deliver optimal user experiences."
 
     [[params.categories.item]]
       term = "ui automation"
+      heading = "Content about UI Automation at Mattermost"
       description = "Check out this repository to read Mattermost content about UI automation."
 
   # Footer section

--- a/site/content/blog/2017-09-04-repo-split.md
+++ b/site/content/blog/2017-09-04-repo-split.md
@@ -1,5 +1,6 @@
 ---
 title: "Platform Repository Splitting"
+heading: "Platform Repository Splitting at Mattermost"
 description: "Here is a reminder that Mattermost separated the /platform repo into two repositories on September 6, 2017."
 slug: repo-split
 date: 2017-09-04T11:09:47-04:00

--- a/site/content/blog/2018-05-22-npm-v6.md
+++ b/site/content/blog/2018-05-22-npm-v6.md
@@ -1,5 +1,6 @@
 ---
 title: "npm@6"
+heading: "Mattermost Switching to npm@6"
 description: "Find out why Mattermost switched to npm@6 in May 2018 and what was needed to upgrade."
 slug: npm-v6
 date: 2018-05-22T10:16:52-04:00

--- a/site/content/blog/2018-06-25-subpath.md
+++ b/site/content/blog/2018-06-25-subpath.md
@@ -1,5 +1,6 @@
 ---
 title: "Subpath Support"
+heading: "Mattermost and Subpath Support"
 description: "Mattermost 5.1 includes support for serving Mattermost from subpaths. Learn how to configure subpaths in production."
 slug: subpath
 date: 2018-06-25T15:35:09-04:00

--- a/site/content/blog/2018-07-18-plugins-v2.md
+++ b/site/content/blog/2018-07-18-plugins-v2.md
@@ -1,5 +1,6 @@
 ---
 title: "Plugin System Overhaul"
+heading: "Mattermost Plugin System Overhaul"
 description: "In 2018, we overhauled our entire plugin system. Read about the biggest challenges and takeaways from that experience."
 slug: plugins-v2
 date: 2018-07-18T15:35:09-04:00

--- a/site/content/blog/2018-10-18-idiomatic-error-handling.md
+++ b/site/content/blog/2018-10-18-idiomatic-error-handling.md
@@ -1,5 +1,6 @@
 ---
 title: "Go: Idiomatic Error Handling"
+heading: "Go: Idiomatic Error Handling"
 description: "At Mattermost, we’re in the midst of an epic to make our error handling code more idiomatic and thus ultimately more accessible."
 slug: idiomatic-error-handling
 date: 2018-10-18T00:00:00-04:00

--- a/site/content/blog/2019-01-24-submitting-great-prs.md
+++ b/site/content/blog/2019-01-24-submitting-great-prs.md
@@ -1,5 +1,6 @@
 ---
 title: "Submitting Great PRs"
+heading: "How to Submit Great PRs"
 description: "Learn how to submit optimal pull requests to increase the chances your contributions are added to open source projects."
 slug: submitting-great-prs
 aliases: [/blog/2019-01-24-submitting-great-prs]

--- a/site/content/blog/2019-04-25-cansecwest-2019-encryption.md
+++ b/site/content/blog/2019-04-25-cansecwest-2019-encryption.md
@@ -1,5 +1,6 @@
 ---
 title: CanSecWest and Encryption in Mattermost
+heading: "CanSecWest and Encryption in Mattermost"
 description: "Check out these takeaways from CanSecWest 2019, which was full of exploits and interesting anecdotes."
 slug: cansecwest-2019-encryption
 date: 2019-04-25T12:00:00-04:00

--- a/site/content/blog/2019-06-04-percona-live-2019.md
+++ b/site/content/blog/2019-06-04-percona-live-2019.md
@@ -1,5 +1,6 @@
 ---
 title: Percona Live 2019 & Database Replication
+heading: "Percona Live 2019: Database Replication"
 description: "Everything you need to know about database replication and how it applies to Mattermost."
 slug: percona-live-2019-database-replication
 date: 2019-06-04T12:00:00-04:00

--- a/site/content/blog/2019-06-05-ldap-nested-groups-modelling-and-representation-in-code.md
+++ b/site/content/blog/2019-06-05-ldap-nested-groups-modelling-and-representation-in-code.md
@@ -1,5 +1,6 @@
 ---
 title: "LDAP Nested Groups: Modelling and Representation in Code"
+heading: "LDAP Nested Groups: Modelling and Representation in Code"
 description: "This post describes what LDAP “nested groups” are and how we ended up modelling and representing them in code."
 slug: ldap-nested-groups-modelling-and-representation-in-code
 author: Martin Kraft

--- a/site/content/blog/2019-07-18-chain-react-2019.md
+++ b/site/content/blog/2019-07-18-chain-react-2019.md
@@ -1,5 +1,6 @@
 ---
 title: Hermes @ Chain React
+heading: "Chain React 2019: Highlights on Hermes"
 description: "Elias Nahum shares his thoughts on learning about Hermes and how it can improve the Mattermost Android app."
 slug: chain-react-2019-higlights-hermes
 date: 2019-07-18T12:00:00-04:00

--- a/site/content/blog/2019-09-29-avoiding-flaky-tests.md
+++ b/site/content/blog/2019-09-29-avoiding-flaky-tests.md
@@ -1,5 +1,6 @@
 ---
 title: "Avoiding Flaky Tests"
+heading: "Avoiding Flaky Tests"
 description: "Flaky tests are no stranger to the Mattermost code base. Find out what we've done to avoid flaky tests."
 slug: avoiding-flaky-tests
 date: 2019-09-29T00:00:00-04:00

--- a/site/content/blog/2019-10-21-debugging-using-charles.md
+++ b/site/content/blog/2019-10-21-debugging-using-charles.md
@@ -1,5 +1,6 @@
 ---
 title: "Debugging Using Charles"
+heading: "Debugging Using Charles"
 description: "Learn about using Charles to debug against community servers while running a local copy of the mattermost webapp."
 slug: debugging-using-charles
 date: 2019-10-21T00:00:00-04:00

--- a/site/content/blog/2019-10-21-localizing-matterpoll/index.md
+++ b/site/content/blog/2019-10-21-localizing-matterpoll/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Localizing Matterpoll"
+heading: "Localizing Matterpoll"
 description: "Matterpoll is a plugin that allows users to create polls in Mattermost. Learn about how we localized it."
 slug: localizing-matterpoll
 date: 2019-12-11T10:49:35+02:00

--- a/site/content/blog/2019-10-25-instrumenting-go-code-via-ast.md
+++ b/site/content/blog/2019-10-25-instrumenting-go-code-via-ast.md
@@ -1,5 +1,6 @@
 ---
 title: "Instrumenting Go code via AST"
+heading: "Instrumenting Go Code via AST - Part 2"
 description: "Learn about what Go AST is, why we need it, and instrumenting our handlers with tracing code."
 slug: instrumenting-go-code-via-ast
 series: "AST"

--- a/site/content/blog/2019-11-04-unit-testing-mmctl-commands.md
+++ b/site/content/blog/2019-11-04-unit-testing-mmctl-commands.md
@@ -1,5 +1,6 @@
 ---
 title: "Unit testing mmctl commands"
+heading: "Unit Testing mmctl Commands"
 description: "Mattermost is starting a new open source campaign, this time around increasing the unit test coverage for the mmctl tool."
 slug: unit-testing-mmctl-commands
 date: 2019-11-07T00:00:00-04:00

--- a/site/content/blog/2019-12-18-cloud-monitoring.md
+++ b/site/content/blog/2019-12-18-cloud-monitoring.md
@@ -1,5 +1,6 @@
 ---
 title: "Monitoring a Multi-Cluster Environment Using Prometheus Federation and Grafana"
+heading: "Monitoring a Multi-Cluster Environment"
 description: "Monitoring the state of your clusters is an effective way to discover bottlenecks in your multi-cluster production environment."
 slug: cloud-monitoring
 date: 2019-12-18T00:00:00-04:00

--- a/site/content/blog/2019-12-18-kubecon-na-2019.md
+++ b/site/content/blog/2019-12-18-kubecon-na-2019.md
@@ -1,5 +1,6 @@
 ---
 title: KubeCon NA 2019
+heading: "KubeCon North American 2019"
 description: "Takeaways from our team's experience at KubeCon + CloudNativeCon North America 2019."
 slug: kubecon-na-2019
 date: 2019-12-18T12:00:00-04:00

--- a/site/content/blog/2019-12-20-hermes-js-engines.md
+++ b/site/content/blog/2019-12-20-hermes-js-engines.md
@@ -1,5 +1,6 @@
 ---
 title: On Hermes and Mattermost
+heading: "On Hermes and Mattermost"
 description: "Read about how Mattermost uses Hermes, Facebook’s new JavaScript engine, to boost performance."
 slug: on-hermes-and-mattermost
 date: 2019-12-20T12:00:00-04:00

--- a/site/content/blog/2019-12-20-onboarding-with-mattermost.md
+++ b/site/content/blog/2019-12-20-onboarding-with-mattermost.md
@@ -1,5 +1,6 @@
 ---
 title: "Onboarding with Mattermost"
+heading: "Onboarding with Mattermost"
 description: "Learn about what the remote onboarding process is like for new hires at Mattermost."
 slug: onboarding-with-mattermost
 date: 2019-12-20T00:00:00-04:00

--- a/site/content/blog/2020-01-13-incorporating-golangci-lint.md
+++ b/site/content/blog/2020-01-13-incorporating-golangci-lint.md
@@ -1,5 +1,6 @@
 ---
 title: Incorporating GolangCI-Lint at Mattermost
+heading: "Incorporating GolangCI-Lint at Mattermost"
 description: "Although go vet and gofmt work well, there are a lot of other powerful linters out there which we’re potentially missing out on."
 slug: incorporating-golangci-lint
 date: 2020-01-13

--- a/site/content/blog/2020-02-26-layered-store-and-struct-embedding.md
+++ b/site/content/blog/2020-02-26-layered-store-and-struct-embedding.md
@@ -1,5 +1,6 @@
 ---
 title: "Layered Store and Struct Embedding in Go"
+heading: "Layered Store and Struct Embedding"
 description: "One of the most important parts of the Mattermost source code is the one responsible for accessing the Mattermost database: the store."
 slug: layered-store-and-struct-embedding
 date: 2020-02-26

--- a/site/content/blog/2020-03-15-instrumenting-go-code-via-ast-2.md
+++ b/site/content/blog/2020-03-15-instrumenting-go-code-via-ast-2.md
@@ -1,5 +1,6 @@
 ---
 title: "Instrumenting Go code via AST, Part 2"
+heading: "Instrumenting Go Code via AST - Part 1"
 description: "This is the second part of our AST blog post series, expanding on the subject of utilizing Go AST libraries to automate and improve your workflow."
 slug: instrumenting-go-code-via-ast-2
 series: "AST"

--- a/site/content/blog/2020-03-26-emojis.md
+++ b/site/content/blog/2020-03-26-emojis.md
@@ -1,5 +1,6 @@
 ---
 title: "All About Emojis"
+heading: "All About Emojis - Mattermost"
 description: "Emojis are a great way to add tone to a piece of text and also help make text-based conversation feel more casual, relaxed, and fun."
 slug: all-about-emojis
 date: 2020-03-26T12:00:00-05:00

--- a/site/content/blog/2020-03-27-advanced-git-tbilisi-free-university.md
+++ b/site/content/blog/2020-03-27-advanced-git-tbilisi-free-university.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced Git with the Free University of Tbilisi
+heading: "Advanced Git with the Free University of Tbilisi"
 description: "Jesse Hallam gives a virtual course on advanced Git at the Free University of Tbilisi."
 slug: advanced-git-tbilisi-free-university
 date: 2020-03-27

--- a/site/content/blog/2020-05-20-hands-on-iouring-go.md
+++ b/site/content/blog/2020-05-20-hands-on-iouring-go.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Hands-on with io_uring using Go
+heading: "Getting Hands on with io_uring using Go"
 description: "In Linux, system calls (syscalls) are at the heart of everything. They are the primary interface through which an application interacts with the kernel."
 slug: hands-on-iouring-go
 date: 2020-05-20

--- a/site/content/contribute/containers/_index.md
+++ b/site/content/contribute/containers/_index.md
@@ -1,10 +1,9 @@
 ---
 title: "Containers"
+heading: "Mattermost Containers and Official Docker Images"
 description: "Mattermost uses Docker to publish the official images for the Mattermost Server, and this page lists all Docker repositories in use."
 section: "contribute"
 ---
-
-# Mattermost Containers
 
 Mattermost uses the [Docker Registry](https://hub.docker.com/u/mattermost) to publish the official images for the Mattermost Server and also for other supporting images that are used for internal/public development and testing.
 

--- a/site/content/contribute/desktop/_index.md
+++ b/site/content/contribute/desktop/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Desktop App"
+heading: "Contribute to the Mattermost Desktop App"
 description: "The Mattermost desktop app is an Electron wrapper around the web app project. It lives in the mattermost/desktop repository."
 date: 2018-01-02T10:36:34-05:00
 section: "contribute"

--- a/site/content/contribute/desktop/code-signing.md
+++ b/site/content/contribute/desktop/code-signing.md
@@ -1,5 +1,6 @@
 ---
 title: "Code Signing"
+heading: "Code Signing at Mattermost"
 description: "When releasing the Mattermost Desktop application for Windows and macOS, we have to sign the executable with a certificate."
 date: 2018-01-16T10:32:51-05:00
 subsection: "Desktop App"

--- a/site/content/contribute/desktop/debugging.md
+++ b/site/content/contribute/desktop/debugging.md
@@ -1,12 +1,11 @@
 ---
 title: "Debugging"
+heading: "Debugging at Mattermost"
 description: "The electron app itself can be inspected using the developer tools, available from the View menu of Safari."
 date: 2019-01-22T00:00:00-05:00
 weight: 3
 subsection: "Debugging"
 ---
-
-# Developer Tools
 
 The electron app itself can be inspected using the developer tools, available from the View menu:
 

--- a/site/content/contribute/desktop/developer-setup.md
+++ b/site/content/contribute/desktop/developer-setup.md
@@ -1,5 +1,6 @@
 ---
 title: "Developer Setup"
+heading: "Developer Setup - Mattermost Desktop App"
 description: "Learn how to set up your developer environment to contribute to the Mattermost desktop app."
 date: 2018-01-02T10:44:11-05:00
 weight: 2

--- a/site/content/contribute/devtalks/_index.md
+++ b/site/content/contribute/devtalks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Mattermost Dev Talks"
+heading: "Mattermost Dev Talks"
 description: "The Mattermost team releases a developer talk that discusses the architecture, design principles, and tools that the Mattermost project uses."
 date: "2017-01-05T09:51:35-05:00"
 section: "contribute"

--- a/site/content/contribute/getting-started/_index.md
+++ b/site/content/contribute/getting-started/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+heading: "Getting Started with Mattermost"
 description: "Learn how you can join the Mattermost community and get started contributing code to Mattermost repositories in GitHub."
 date: "2018-05-19T12:01:23-04:00"
 section: "contribute"

--- a/site/content/contribute/getting-started/branching.md
+++ b/site/content/contribute/getting-started/branching.md
@@ -1,5 +1,6 @@
 ---
 title: "Mattermost tick-tock Branching Strategy"
+heading: "Mattermost Tick-Tock Branching Strategy"
 description: "Mattermost recently moved away from a tick-tock release strategy with alternating feature and quality releases."
 date: 2019-06-18T00:00:00-04:00
 weight: 20

--- a/site/content/contribute/getting-started/code-review.md
+++ b/site/content/contribute/getting-started/code-review.md
@@ -1,5 +1,6 @@
 ---
 title: "Code Review"
+heading: "Code Review at Mattermost"
 description: "All changes to the Mattermost product must be reviewed. Learn about how Mattermost reviews product updates."
 date: 2018-03-06T00:00:00-04:00
 weight: 5

--- a/site/content/contribute/getting-started/contribution-checklist.md
+++ b/site/content/contribute/getting-started/contribution-checklist.md
@@ -1,5 +1,6 @@
 ---
 title: "Contribution Checklist"
+heading: "Mattermost Contribution Checklist"
 description: "Join our Contributors community channel where you can discuss questions with community members and the Mattermost core team."
 date: 2017-08-20T12:33:36-04:00
 weight: 1

--- a/site/content/contribute/getting-started/contributions-without-ticket.md
+++ b/site/content/contribute/getting-started/contributions-without-ticket.md
@@ -1,5 +1,6 @@
 ---
 title: "Contributions Without Ticket"
+heading: "Contributing to Mattermost without a Ticket"
 description: "Contributions for minor corrections and improvements without a corresponding Help Wanted ticket are welcome."
 date: 2019-10-11T15:44:36-02:00
 weight: 1

--- a/site/content/contribute/getting-started/core-committers.md
+++ b/site/content/contribute/getting-started/core-committers.md
@@ -1,5 +1,6 @@
 ---
 title: "Core Committers"
+heading: "Mattermost Core Committers"
 description: "A core committer is a maintainer on the Mattermost project that has merge access to Mattermost repositories. Learn more about the team here."
 date: 2017-08-20T12:33:36-04:00
 weight: 4

--- a/site/content/contribute/getting-started/inactive-contributions.md
+++ b/site/content/contribute/getting-started/inactive-contributions.md
@@ -1,5 +1,6 @@
 ---
 title: "Inactive Contributions"
+heading: "Managing Inactive Contributions at Mattermost"
 description: "This process describes how inactive contributions are managed at Mattermost, inspired by the Kubernetes project."
 date: 2017-08-20T12:33:36-04:00
 weight: 1.5

--- a/site/content/contribute/getting-started/labels.md
+++ b/site/content/contribute/getting-started/labels.md
@@ -1,5 +1,6 @@
 ---
 title: "Labels"
+heading: "Using Labels to Track Issues and PRs at Mattermost"
 description: "We leverage GitHub labels to track the details and lifecycle of issues and pull requests. Learn what our labels mean."
 date: 2018-03-06T00:00:00-04:00
 weight: 5

--- a/site/content/contribute/getting-started/slash-commands.md
+++ b/site/content/contribute/getting-started/slash-commands.md
@@ -1,5 +1,6 @@
 ---
 title: "Slash Commands"
+heading: "Getting Started with Mattermost Slash Commands"
 description: "There are some slash commands available on GitHub that can be implemented via Mattermod. Learn more about what they are."
 weight: 30
 subsection: Getting Started

--- a/site/content/contribute/mobile/_index.md
+++ b/site/content/contribute/mobile/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Mobile Apps"
+heading: "Mattermost Mobile Apps"
 description: "The Mattermost mobile apps are written in JavaScript using React Native. Learn more about our mobile app repo, community channel and more."
 date: "2018-02-19T12:01:23-04:00"
 section: "contribute"

--- a/site/content/contribute/mobile/build-your-own/_index.md
+++ b/site/content/contribute/mobile/build-your-own/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Build Your Own App"
+heading: "Build Your Own Mattermost App"
 description: "Learn how to build your own Mattermost mobile app and distribute it within your team."
 date: 2018-05-20T11:35:32-04:00
 weight: 2

--- a/site/content/contribute/mobile/build-your-own/android.md
+++ b/site/content/contribute/mobile/build-your-own/android.md
@@ -1,5 +1,6 @@
 ---
 title: "Build the Android App"
+heading: "How to Build a Mattermost Android app"
 description: "At times, you may want to build your own Mattermost mobile app. Learn how you can go about doing it."
 date: 2018-05-20T11:35:32-04:00
 weight: 1

--- a/site/content/contribute/mobile/build-your-own/ios.md
+++ b/site/content/contribute/mobile/build-your-own/ios.md
@@ -1,5 +1,6 @@
 ---
 title: "Build the iOS App"
+heading: "Building an iOS Mattermost App"
 description: "At times, you may want to build your own Mattermost mobile app. This page guides you through that process."
 date: 2018-05-20T11:35:32-04:00
 weight: 2

--- a/site/content/contribute/mobile/build-your-own/white-label.md
+++ b/site/content/contribute/mobile/build-your-own/white-label.md
@@ -1,5 +1,6 @@
 ---
 title: "White Labeling"
+heading: "White Labeling Mattermost"
 description: "Learn how to white label the Mattermost Mobile app, and how to replace and override the assets used for your Mattermost deployment."
 date: 2018-05-20T11:35:32-04:00
 weight: 3

--- a/site/content/contribute/mobile/developer-setup/_index.md
+++ b/site/content/contribute/mobile/developer-setup/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Developer Setup"
+heading: "Developer Setup for Mattermost Mobile Apps"
 description: "The following instructions apply to the mobile apps for iOS and Android built in React Native."
 date: 2017-08-20T11:35:32-04:00
 weight: 1

--- a/site/content/contribute/mobile/developer-setup/dependecies.md
+++ b/site/content/contribute/mobile/developer-setup/dependecies.md
@@ -1,5 +1,6 @@
 ---
 title: "Add new dependencies"
+heading: "Adding New Dependencies in Mattermost"
 description: "If you need to add a new dependency to the project, it is important to add them in the right way. Find out how."
 date: 2018-05-20T11:35:32-04:00
 weight: 4

--- a/site/content/contribute/mobile/developer-setup/run.md
+++ b/site/content/contribute/mobile/developer-setup/run.md
@@ -1,5 +1,6 @@
 ---
 title: Run the app
+heading: "Running the Mattermost App"
 description: "Mattermost provides a set of scripts to help you run the app for different platforms. Learn about them here."
 date: 2018-05-20T11:35:32-04:00
 weight: 2

--- a/site/content/contribute/mobile/developer-setup/structure.md
+++ b/site/content/contribute/mobile/developer-setup/structure.md
@@ -1,5 +1,6 @@
 ---
 title: "Folder Structure"
+heading: "Folder Structure at Mattermost"
 date: 2018-05-20T11:35:32-04:00
 weight: 1
 subsection: Developer Setup

--- a/site/content/contribute/mobile/e2e/_index.md
+++ b/site/content/contribute/mobile/e2e/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Mobile End-to-End Testing"
+heading: "Mobile End-to-End Testing at Mattermost"
 description: "This page describes how to write and run End-to-End (E2E) testing for Mobile Apps for both iOS and Android."
 date: 2020-09-01T09:00:00-00:00
 weight: 6

--- a/site/content/contribute/mobile/e2e/android.md
+++ b/site/content/contribute/mobile/e2e/android.md
@@ -1,5 +1,6 @@
 ---
 title: "Setup and Run Android E2E"
+heading: "Setup and Run Android E2E"
 description: "Learn how to set up and run Android end-to-end (E2E) testing to ensure mobile apps operate as designed."
 date: 2020-09-01T09:00:00-00:00
 weight: 3

--- a/site/content/contribute/mobile/e2e/environment-vars.md
+++ b/site/content/contribute/mobile/e2e/environment-vars.md
@@ -1,5 +1,6 @@
 ---
 title: "Environment Variables"
+heading: "Environment Variables at Mattermost"
 description: "At Mattermost, we use several environment variables for Detox testing. Find out the two main reasons why."
 date: 2020-10-06T09:00:00-00:00
 weight: 7

--- a/site/content/contribute/mobile/e2e/file-structure.md
+++ b/site/content/contribute/mobile/e2e/file-structure.md
@@ -1,5 +1,6 @@
 ---
 title: "Folder and File Structure"
+heading: "Mattermost Folder and File Structure"
 description: "Learn about the folder structure, which is mostly based on the Detox scaffold which was created on initial run."
 date: 2020-09-02T09:00:00-00:00
 weight: 2

--- a/site/content/contribute/mobile/e2e/guide-for-writing.md
+++ b/site/content/contribute/mobile/e2e/guide-for-writing.md
@@ -1,5 +1,6 @@
 ---
 title: "Guide for Writing E2E"
+heading: "Guide for Writing E2E Tests at Mattermost"
 description: "Interested in writing an end-to-end testing script? Follow this guide to learn what needs to be done."
 date: 2020-09-01T09:00:00-00:00
 weight: 5

--- a/site/content/contribute/mobile/e2e/ios.md
+++ b/site/content/contribute/mobile/e2e/ios.md
@@ -1,5 +1,6 @@
 ---
 title: "Setup and Run iOS E2E"
+heading: "Setting up and Running iOS End-to-End Tests"
 description: "Find out how to set up and run end-to-end testing with iOS and conduct a test run in debug mode and release mode."
 date: 2020-09-01T09:00:00-00:00
 weight: 4

--- a/site/content/contribute/mobile/push-notifications/_index.md
+++ b/site/content/contribute/mobile/push-notifications/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Setup Push Notifications"
+heading: "Setting up Push Notifications - Mattermost"
 description: "Learn how to set up push notifications in your Mattermost mobile application."
 date: 2015-05-20T11:35:32-04:00
 weight: 3

--- a/site/content/contribute/mobile/push-notifications/android.md
+++ b/site/content/contribute/mobile/push-notifications/android.md
@@ -1,5 +1,6 @@
 ---
 title: "Android Push Notifications"
+heading: "Android Push Notifications at Mattermost"
 description: "Learn how Android push notifications work using Mattermost and Firebase Cloud Messaging."
 date: 2015-05-20T11:35:32-04:00
 weight: 1

--- a/site/content/contribute/mobile/push-notifications/corporate-proxy.md
+++ b/site/content/contribute/mobile/push-notifications/corporate-proxy.md
@@ -1,5 +1,6 @@
 ---
 title: "Push Notification Service with Corporate Proxy"
+heading: "Push Notification Service with Corporate Proxy"
 description: "Receiving mobile push notifications in Mattermost if the use of a corporate proxy server is required by your IT policy."
 date: 2020-03-09T11:35:32
 weight: 4

--- a/site/content/contribute/mobile/push-notifications/ios.md
+++ b/site/content/contribute/mobile/push-notifications/ios.md
@@ -1,5 +1,6 @@
 ---
 title: "iOS Push Notifications"
+heading: "iOS Push Notifications on Mattermost"
 description: "Push notifications on iOS are managed and dispatched using Apple’s Push Notification Service. Learn how to use this service with Mattermost."
 date: 2015-05-20T11:35:32-04:00
 weight: 2

--- a/site/content/contribute/mobile/push-notifications/service.md
+++ b/site/content/contribute/mobile/push-notifications/service.md
@@ -1,5 +1,6 @@
 ---
 title: "Push Notification Service"
+heading: "Installing the Mattermost Push Notification Service"
 description: "This guide focuses on installing and configuring the push notification service for Mattermost apps."
 date: 2015-05-20T11:35:32-04:00
 weight: 3

--- a/site/content/contribute/mobile/unsigned/_index.md
+++ b/site/content/contribute/mobile/unsigned/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Sign Unsigned Builds"
+heading: "Signing Unsigned Builds with Mattermost"
 description: "Mattermost publishes an unsigned build of the mobile app in the GitHub Releases page with every version that gets released."
 date: 2018-05-20T11:35:32-04:00
 weight: 4

--- a/site/content/contribute/mobile/unsigned/android.md
+++ b/site/content/contribute/mobile/unsigned/android.md
@@ -1,5 +1,6 @@
 ---
 title: "Sign Unsigned Android"
+heading: "Sign Unsigned Android Builds - Mattermost"
 description: "Learn the steps needed to modify and sign the Mattermost mobile app so it can be distributed and installed on Android devices."
 date: 2018-05-20T11:35:32-04:00
 weight: 1

--- a/site/content/contribute/mobile/unsigned/ios.md
+++ b/site/content/contribute/mobile/unsigned/ios.md
@@ -1,5 +1,6 @@
 ---
 title: "Sign Unsigned iOS"
+heading: "Signing Unsigned iOS Builds in Mattermost"
 description: "Learn about the steps needed to modify and sign the Mattermost app so it can be distributed and installed on iOS devices."
 date: 2018-05-20T11:35:32-04:00
 weight: 2

--- a/site/content/contribute/mvp/_index.md
+++ b/site/content/contribute/mvp/_index.md
@@ -1,10 +1,9 @@
 ---
 title: "MVP"
+heading: "Mattermost Hall of Fame"
 description: "Hundreds of developers around the world contribute to Mattermost open source projects. Our Hall of Fame honors the best of the best."
 section: "contribute"
 ---
-
-# Mattermost Hall of Fame
 
 Hundreds of developers around the world contribute to Mattermost open source projects. Our Hall of Fame honors the best of the best.
 

--- a/site/content/contribute/plugins/_index.md
+++ b/site/content/contribute/plugins/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Plugins"
+heading: "Mattermost Plugins: An Introduction"
 description: "Mattermost plugins are isolated pieces of code written in Go and/or React. They’re separate from the main repositories."
 date: "2018-03-19T12:01:23-04:00"
 section: "contribute"

--- a/site/content/contribute/redux/_index.md
+++ b/site/content/contribute/redux/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Redux"
+heading: "The Mattermost-Redux Library"
 description: "The mattermost-redux library is the driver powering both the Mattermost web app and React Native mobile apps."
 date: "2018-01-19T12:01:23-04:00"
 section: "contribute"

--- a/site/content/contribute/redux/actions.md
+++ b/site/content/contribute/redux/actions.md
@@ -1,5 +1,6 @@
 ---
 title: "Actions"
+heading: "Actions in Redux - Mattermost"
 description: "Similar to other frameworks like Flux, actions in Redux represent a single change to the Redux store as a plain JavaScript object."
 date: 2017-08-20T11:35:32-04:00
 weight: 4

--- a/site/content/contribute/redux/developer-setup.md
+++ b/site/content/contribute/redux/developer-setup.md
@@ -1,5 +1,6 @@
 ---
 title: "Developer Setup"
+heading: "Redux - Developer Setup - Mattermost"
 description: "Find out how to configure your developer environment using Redux, as well as the prerequisites you'll need."
 date: 2017-08-20T11:35:32-04:00
 weight: 2

--- a/site/content/contribute/redux/developer-workflow.md
+++ b/site/content/contribute/redux/developer-workflow.md
@@ -1,5 +1,6 @@
 ---
 title: "Redux Workflow"
+heading: "Redux Workflow at Mattermost"
 description: "Learn about the Mattermost Redux repository, useful commands to know, how to submit a pull request, and more."
 date: 2017-08-20T11:35:32-04:00
 weight: 3

--- a/site/content/contribute/redux/react-redux.md
+++ b/site/content/contribute/redux/react-redux.md
@@ -1,5 +1,6 @@
 ---
 title: "Using Redux with React"
+heading: "Using Redux with React in Mattermost"
 description: "Find out how using Redux with React is fairly straightforward thanks to the React Redux library."
 date: 2017-08-20T11:35:32-04:00
 weight: 7

--- a/site/content/contribute/redux/reducers.md
+++ b/site/content/contribute/redux/reducers.md
@@ -1,5 +1,6 @@
 ---
 title: "Reducers"
+heading: "Reducers in Redux at Mattermost"
 description: "Reducers in Redux are pure functions that describe how the data in the store changes after any given action."
 date: 2017-08-20T11:35:32-04:00
 weight: 5

--- a/site/content/contribute/redux/selectors.md
+++ b/site/content/contribute/redux/selectors.md
@@ -1,5 +1,6 @@
 ---
 title: "Selectors"
+heading: "How to Use Selectors - Mattermost"
 description: "Find out what selectors are and how to use, add, and test them in Mattermost."
 date: 2017-08-20T11:35:32-04:00
 weight: 6

--- a/site/content/contribute/server/_index.md
+++ b/site/content/contribute/server/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Server"
+heading: "An Introduction to the Mattermost Server"
 description: "The server, which is written in Go and compiles on a single binary, is the highly scalable backbone of the Mattermost project."
 date: "2018-04-19T12:01:23-04:00"
 section: "contribute"

--- a/site/content/contribute/server/cli-commands.md
+++ b/site/content/contribute/server/cli-commands.md
@@ -1,5 +1,6 @@
 ---
 title: "CLI Commands"
+heading: "CLI Commands in Mattermost"
 description: "Mattermost provides a CLI (command-line interface) to administer and handle specific administrative tasks."
 date: 2018-09-21T18:40:32-04:00
 weight: 5

--- a/site/content/contribute/server/dependencies.md
+++ b/site/content/contribute/server/dependencies.md
@@ -1,5 +1,6 @@
 ---
 title: "Dependencies"
+heading: "Managing Dependencies in Mattermost"
 description: "The Mattermost server uses go modules to manage dependencies. To manage dependencies you must have modules enabled."
 date: 2019-03-27T16:00:00-0700
 weight: 5

--- a/site/content/contribute/server/developer-setup.md
+++ b/site/content/contribute/server/developer-setup.md
@@ -1,5 +1,6 @@
 ---
 title: "Developer Setup"
+heading: "Setting up Your Development Environment - Mattermost"
 description: "Find out how to set up your development environment for building, running, and testing the Mattermost server."
 date: 2020-02-01T19:50:32-04:00
 weight: 2

--- a/site/content/contribute/server/developer-setup/arch.md
+++ b/site/content/contribute/server/developer-setup/arch.md
@@ -1,5 +1,6 @@
 ---
 title: "Arch Linux Development Environment Setup"
+heading: "Developer Setup - Arch Linux"
 description: "Read about how to set up your developer environment in Mattermost using Arch Linux."
 ---
 

--- a/site/content/contribute/server/developer-setup/centos.md
+++ b/site/content/contribute/server/developer-setup/centos.md
@@ -1,5 +1,6 @@
 ---
 title: "CentOS Development Environment Setup"
+heading: "Developer Setup Using CentOS"
 description: "Read about how to set up your developer environment in Mattermost using the CentOS distribution of Linux."
 ---
 

--- a/site/content/contribute/server/developer-setup/osx.md
+++ b/site/content/contribute/server/developer-setup/osx.md
@@ -1,5 +1,6 @@
 ---
 title: "OSX Development Environment Setup"
+heading: "How to Set Up Mattermost in Mac OS X"
 description: "Read about how to set up your developer environment in Mattermost using a Mac OS X."
 ---
 

--- a/site/content/contribute/server/developer-setup/ubuntu.md
+++ b/site/content/contribute/server/developer-setup/ubuntu.md
@@ -1,3 +1,7 @@
+---
+title: "Mattermost Developer Setup: Ubuntu"
+heading: "Mattermost Developer Setup: Ubuntu"
+---
 1. Install and configure Docker CE:
 
     ```sh

--- a/site/content/contribute/server/developer-setup/windows-wsl.md
+++ b/site/content/contribute/server/developer-setup/windows-wsl.md
@@ -1,5 +1,6 @@
 ---
 title: "Windows with WSL Development Environment Setup"
+heading: "Developer Setup for the Windows Subsystem for Linux"
 description: "Read about how to set up your developer environment in Mattermost using the Windows Subsystem for Linux."
 ---
 

--- a/site/content/contribute/server/developer-workflow.md
+++ b/site/content/contribute/server/developer-workflow.md
@@ -1,5 +1,6 @@
 ---
 title: "Server Workflow"
+heading: "Mattermost Server Workflow"
 description: "See what a general workflow for a Mattermost developer working on the mattermost-server repository looks like."
 date: 2017-08-20T11:35:32-04:00
 weight: 3

--- a/site/content/contribute/server/feature-flags.md
+++ b/site/content/contribute/server/feature-flags.md
@@ -1,5 +1,6 @@
 ---
 title: "Feature Flags"
+heading: "Feature Flags and Mattermost Cloud"
 description: "Feature flags allow us to be more confident in shipping features continuously to Mattermost Cloud. Find out why."
 date: 2020-10-15T16:00:00-0700
 weight: 3

--- a/site/content/contribute/server/plugins.md
+++ b/site/content/contribute/server/plugins.md
@@ -1,5 +1,6 @@
 ---
 title: "Plugins"
+heading: "Plugins at Mattermost"
 description: "Mattermost supports plugins to extend and integrate server and web/desktop apps. Learn about our plugin infrastructure and how to contribute."
 date: 2017-08-20T11:35:32-04:00
 weight: 5

--- a/site/content/contribute/server/rest-api.md
+++ b/site/content/contribute/server/rest-api.md
@@ -1,5 +1,6 @@
 ---
 title: "REST API"
+heading: "Information about the Mattermost REST API"
 description: "The REST API is a JSON web service that facilitates communication between Mattermost clients, as well as integrations, and the server."
 date: 2017-08-20T11:35:32-04:00
 weight: 4

--- a/site/content/contribute/server/system_console.md
+++ b/site/content/contribute/server/system_console.md
@@ -1,5 +1,6 @@
 ---
 title: "System Console"
+heading: "The Mattermost System Console"
 description: "Find out how to add fields, expose settings, and make settings available for non-admins in the System Console."
 date: 2019-10-09T13:38:26-04:00
 weight: 5

--- a/site/content/contribute/server/tooling.md
+++ b/site/content/contribute/server/tooling.md
@@ -1,5 +1,6 @@
 ---
 title: Tooling
+heading: "Mattermost Server - Tooling"
 description: "Learn more about the tooling that is required to set up the developer's environment."
 date: 2020-04-22T17:52:04-05:00
 subsection: internal

--- a/site/content/contribute/team_contributions/_index.md
+++ b/site/content/contribute/team_contributions/_index.md
@@ -1,10 +1,9 @@
 ---
 title: "Contributor Wall of Fame"
+heading: "Contributor Hall of Fame"
 description: "Check out the Mattermost Contributor Hall of Fame to learn about the incredible people who've contributed to Mattermost over the years."
 section: "contribute"
 ---
-
-# Mattermost Contributor Wall of Fame
 
 Mattermost is an open source Slack-alternative that helps teams stay in sync, with messaging and file sharing across PCs and phones, with archiving and search, and a growing community of integrations, bots and applications.
 

--- a/site/content/contribute/webapp/_index.md
+++ b/site/content/contribute/webapp/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Web App"
+heading: "Contribute to the Mattermost Web App"
 description: "The Mattermost web app is written in JavaScript using React and Redux and is powered by mattermost-redux."
 date: "2018-03-19T12:01:23-04:00"
 section: "contribute"

--- a/site/content/contribute/webapp/build-component.md
+++ b/site/content/contribute/webapp/build-component.md
@@ -1,5 +1,6 @@
 ---
 title: "Build a Component"
+heading: "How to Build a Component in Mattermost"
 description: "This page describes how to build a new React component in the Mattermost webapp and the requirements it must meet."
 date: 2017-08-20T11:35:32-04:00
 weight: 4

--- a/site/content/contribute/webapp/developer-workflow.md
+++ b/site/content/contribute/webapp/developer-workflow.md
@@ -1,5 +1,6 @@
 ---
 title: "Web App Workflow"
+heading: "Mattermost Web App Workflow"
 description: "See what a general workflow for a Mattermost developer working on the mattermost-webapp repository looks like."
 date: 2017-08-20T11:35:32-04:00
 weight: 3

--- a/site/content/contribute/webapp/end-to-end-tests.md
+++ b/site/content/contribute/webapp/end-to-end-tests.md
@@ -1,5 +1,6 @@
 ---
 title: "End-to-End Testing"
+heading: "End-to-end Testing in Mattermost"
 description: "This page describes how to run End-to-End (E2E) testing and to build tests for a section or page of the Mattermost web application."
 date: 2018-12-04T11:35:32-04:00
 weight: 6

--- a/site/content/contribute/webapp/migrating-to-typescript.md
+++ b/site/content/contribute/webapp/migrating-to-typescript.md
@@ -1,5 +1,6 @@
 ---
 title: "Migrating to Typescript"
+heading: "Migrating to Typescript - Mattermost"
 description: "We introduced Typescript to our codebase to proactively improve the quality, security, and stability of the code."
 date: 2020-07-11T23:00:00-04:00
 weight: 9

--- a/site/content/contribute/webapp/unit-testing.md
+++ b/site/content/contribute/webapp/unit-testing.md
@@ -1,5 +1,6 @@
 ---
 title: "Unit Testing"
+heading: "Unit Testing at Mattermost"
 description: "Review our guidelines for unit testing for your Mattermost webapp, including a guide on how to do component testing."
 date: 2018-11-20T11:35:32-04:00
 weight: 5

--- a/site/content/contribute/webapp/using-i18n-extract.md
+++ b/site/content/contribute/webapp/using-i18n-extract.md
@@ -1,5 +1,6 @@
 ---
 title: "Using make i18n-extract"
+heading: "Using make i18n-extract at Mattermost"
 description: "This command used for localization allows you to validate that your strings have been successfully extracted from your source code."
 date: 2020-04-20T08:31:17-04:00
 weight: 7

--- a/site/content/contribute/webapp/webapp-to-redux.md
+++ b/site/content/contribute/webapp/webapp-to-redux.md
@@ -1,5 +1,6 @@
 ---
 title: "Migrating to Redux"
+heading: "Migrating to Redux - Mattermost"
 description: "The Mattermost web app is going through a big restructuring effort to move from using Flux to Redux."
 date: 2017-08-20T11:35:32-04:00
 weight: 8

--- a/site/content/extend/customization/_index.md
+++ b/site/content/extend/customization/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Customizing Mattermost"
+heading: "Customizing Mattermost: An Introduction"
 description: "Learn more about customizing Mattermost to create a more personalized experience depending on the needs of your deployment."
 date: "2017-10-29T13:47:55+09:00"
 section: "extend"

--- a/site/content/extend/customization/server-build.md
+++ b/site/content/extend/customization/server-build.md
@@ -1,5 +1,6 @@
 ---
 title: "Server Build (Team Edition)"
+heading: "Server Build - Mattermost Team Edition"
 description: "Find out how to customize and build your own version of the Mattermost open source project."
 date: 2018-05-20T11:35:32-04:00
 weight: 1

--- a/site/content/extend/customization/server-files.md
+++ b/site/content/extend/customization/server-files.md
@@ -1,5 +1,6 @@
 ---
 title: "Server Files"
+heading: "Mattermost Server Files"
 description: "In Mattermost, you have the freedom to alter how content is displayed by being able to change the contents of localized files and email templates."
 date: 2018-05-20T11:35:32-04:00
 weight: 1

--- a/site/content/extend/customization/webapp.md
+++ b/site/content/extend/customization/webapp.md
@@ -1,5 +1,6 @@
 ---
 title: "Web App"
+heading: "Customize the Mattermost Web App"
 description: "Learn about customizations to the Mattermost Web App that can be performed when you need to customized branding, functionality or security."
 date: 2018-05-20T11:35:32-04:00
 weight: 1

--- a/site/content/extend/embed/_index.md
+++ b/site/content/extend/embed/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Embed"
+heading: "Embedding Plugins with Mattermost"
 description: "With Mattermost’s rich RESTful web service API and OAuth 2.0 support, you can build your own clients to embed Mattermost within any application."
 date: 2017-05-10T00:00:00-05:00
 section: extend

--- a/site/content/extend/getting-started/_index.md
+++ b/site/content/extend/getting-started/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+heading: "Getting Started with Mattermost"
 description: "Mattermost can be extended by building and installing plugins, embedding Mattermost in another app, or forking the codebase."
 date: "2018-04-19T12:01:23-04:00"
 section: "extend"

--- a/site/content/extend/plugins/_index.md
+++ b/site/content/extend/plugins/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Plugins (Beta)
+heading: "Plugins in Mattermost"
 description: "Mattermost supports plugins that offer powerful features for extending and deeply integrating with both the server and web/desktop apps."
 date: 2017-07-10T00:00:00-05:00
 section: extend

--- a/site/content/extend/plugins/best-practices.md
+++ b/site/content/extend/plugins/best-practices.md
@@ -1,5 +1,6 @@
 ---
 title: "Best Practices"
+heading: "Best Practices for Plugins"
 description: "Learn more about best practices for using Mattermost plugins to better extend and integrate your Mattermost server and apps."
 subsection: Plugins (Beta)
 weight: 90

--- a/site/content/extend/plugins/community-plugin-marketplace.md
+++ b/site/content/extend/plugins/community-plugin-marketplace.md
@@ -1,5 +1,6 @@
 ---
 title: Community Plugins in the Marketplace
+heading: "Community Plugins in the Plugin Marketplace"
 description: "Once your plugin has reached a certain level of quality, you might consider submitting it to the Plugin Marketplace."
 subsection: Plugins (Beta)
 weight: 60

--- a/site/content/extend/plugins/community_process.md
+++ b/site/content/extend/plugins/community_process.md
@@ -1,5 +1,6 @@
 ---
 title: Process to Include Plugin on Community
+heading: "Process to Include Plugins on Community"
 description: "Getting your project on the Community server is a great way to get valuable feedback from Mattermost users and staff."
 date: 2018-10-01T00:00:00-05:00
 subsection: Plugins (Beta)

--- a/site/content/extend/plugins/developer-setup.md
+++ b/site/content/extend/plugins/developer-setup.md
@@ -1,5 +1,6 @@
 ---
 title: "Developer Setup"
+heading: "Mattermost Developer Setup"
 description: "Learn how to set up your Mattermost environment to develop and deploy plugins with our guide to Developer Setup."
 date: 2020-07-11T23:00:00-04:00
 weight: 2

--- a/site/content/extend/plugins/developer-workflow.md
+++ b/site/content/extend/plugins/developer-workflow.md
@@ -1,5 +1,6 @@
 ---
 title: "Developer Workflow"
+heading: "Developer Workflow at Mattermost"
 description: "Read about developer workflows and learn how work with plugins and debug them in Mattermost."
 date: 2020-07-11T23:00:00-04:00
 weight: 3

--- a/site/content/extend/plugins/example-plugins.md
+++ b/site/content/extend/plugins/example-plugins.md
@@ -1,5 +1,6 @@
 ---
 title: "Example Plugins"
+heading: "Example Plugins in Mattermost"
 description: "To get started extending server-side functionality with plugins, take a look at our server “Hello, world!” tutorial."
 date: 2018-07-10T00:00:00-05:00
 subsection: Plugins (Beta)

--- a/site/content/extend/plugins/helpers.md
+++ b/site/content/extend/plugins/helpers.md
@@ -1,5 +1,6 @@
 ---
 title: Plugin Helpers
+heading: "Plugin Helpers at Mattermost"
 description: "Learn when to write a new plugin helper, a new API method, and a new hook for Mattermost."
 date: 2019-09-30T00:00:00-05:00
 subsection: Plugins (Beta)

--- a/site/content/extend/plugins/manifest-reference.md
+++ b/site/content/extend/plugins/manifest-reference.md
@@ -1,5 +1,6 @@
 ---
 title: "Manifest Reference"
+heading: "Manifest Reference at Mattermost"
 description: "The plugin manifest defines the metadata required to load and present your plugin in Mattermost."
 date: 2018-07-10T00:00:00-05:00
 subsection: Plugins (Beta)

--- a/site/content/extend/plugins/migration.md
+++ b/site/content/extend/plugins/migration.md
@@ -1,5 +1,6 @@
 ---
 title: Migrating Plugins
+heading: "Migrating Plugins from Mattermost 5.5"
 description: "The plugin package exposed by Mattermost 5.6 and later drops support for automatically unmarshalling a plugin’s configuration onto the struct embedding MattermostPlugin."
 date: 2018-10-01T00:00:00-05:00
 subsection: Plugins (Beta)

--- a/site/content/extend/plugins/mobile/_index.md
+++ b/site/content/extend/plugins/mobile/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Mobile Plugins
+heading: "Mobile Plugins at Mattermost"
 description: "Full support for mobile plugins is still a work in progress. See where things stand and learn what you can do."
 date: 2018-07-10T00:00:00-05:00
 subsection: Plugins (Beta)

--- a/site/content/extend/plugins/overview.md
+++ b/site/content/extend/plugins/overview.md
@@ -1,5 +1,6 @@
 ---
 title: Overview
+heading: "An Overview of Mattermost Plugins"
 description: "Plugins are defined by a manifest file and contain at least a server or web app component, or both. Learn more in our overview of plugins."
 date: 2018-07-10T00:00:00-05:00
 subsection: Plugins (Beta)

--- a/site/content/extend/plugins/server/_index.md
+++ b/site/content/extend/plugins/server/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Server Plugins
+heading: "Mattermost Server Plugins"
 description: "Server plugins are subprocesses invoked by the server that communicate with Mattermost using remote procedure calls (RPC)."
 date: 2018-07-10T00:00:00-05:00
 subsection: Plugins (Beta)

--- a/site/content/extend/plugins/server/best-practices.md
+++ b/site/content/extend/plugins/server/best-practices.md
@@ -1,5 +1,6 @@
 ---
 title: Best Practices
+heading: "Best Practices for Plugins on Mattermost"
 description: "Read about some of the best practices for working with plugins in Mattermost."
 subsection: Server Plugins
 weight: 0

--- a/site/content/extend/plugins/server/debugging.md
+++ b/site/content/extend/plugins/server/debugging.md
@@ -1,5 +1,6 @@
 ---
 title: "Debugging Server Plugins"
+heading: "Debugging the Mattermost Server"
 description: "Plugins communicate with the main Mattermost server by RPC. Learn how to debug them."
 ---
 

--- a/site/content/extend/plugins/server/ha.md
+++ b/site/content/extend/plugins/server/ha.md
@@ -1,5 +1,6 @@
 ---
 title: High Availability
+heading: "Mattermost Enterprise Edition E20: High Availability"
 description: "All Mattermost plugins should consider High Availability (HA) environments. Learn more about our standards for workign with HA mode servers."
 date: 2018-07-10T00:00:00-05:00
 subsection: Server Plugins

--- a/site/content/extend/plugins/server/hello-world.md
+++ b/site/content/extend/plugins/server/hello-world.md
@@ -1,5 +1,6 @@
 ---
 title: Quick Start
+heading: "Writing a Mattermost Plugin"
 description: "This tutorial will walk you through the basics of writing a Mattermost plugin with a server component."
 date: 2018-07-10T00:00:00-05:00
 subsection: Server Plugins

--- a/site/content/extend/plugins/server/reference.md
+++ b/site/content/extend/plugins/server/reference.md
@@ -1,5 +1,6 @@
 ---
 title: Server Reference
+heading: "Mattermost Server Reference"
 description: "The plugin package is used by Mattermost server plugins written in Go and enables you to manage and interact with the plugin environment."
 date: 2018-07-10T00:00:00-05:00
 subsection: Server Plugins

--- a/site/content/extend/plugins/source-available-license.md
+++ b/site/content/extend/plugins/source-available-license.md
@@ -1,5 +1,6 @@
 ---
 title: "Source Available License"
+heading: "Mattermost Source Available License"
 description: "Some plugins authored by Mattermost are licensed under the Mattermost Source Available License."
 subsection: Plugins (Beta)
 weight: 91

--- a/site/content/extend/plugins/webapp/_index.md
+++ b/site/content/extend/plugins/webapp/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Web App Plugins
+heading: "Web App Plugins at Mattermost"
 description: "Web app plugins extend and modify the Mattermost web and desktop apps, without having to fork and rebase on every Mattermost release."
 date: 2018-07-10T00:00:00-05:00
 subsection: Plugins (Beta)

--- a/site/content/extend/plugins/webapp/actions.md
+++ b/site/content/extend/plugins/webapp/actions.md
@@ -1,5 +1,6 @@
 ---
 title: Redux Actions
+heading: "Redux Actions for Web App Plugins"
 description: "Mattermost-redux is a library of shared code between Mattermost JavaScript clients. Learn how to use Redux actions with a plugin."
 date: 2018-07-10T00:00:00-05:00
 subsection: Web App Plugins

--- a/site/content/extend/plugins/webapp/best-practices.md
+++ b/site/content/extend/plugins/webapp/best-practices.md
@@ -1,5 +1,6 @@
 ---
 title: Best Practices
+heading: "Best Practices for Plugins - Mattermost"
 description: "Thinking about adding a plugin to Mattermost? Check out these design best practices."
 subsection: Web App Plugins
 weight: 0

--- a/site/content/extend/plugins/webapp/hello-world.md
+++ b/site/content/extend/plugins/webapp/hello-world.md
@@ -1,5 +1,6 @@
 ---
 title: Quick Start
+heading: "Quick Start: Extending the Mattermost Web App"
 description: "This quickstart tutorial will walk you through the basics of extending the Mattermost web app using plugins."
 date: 2018-07-10T00:00:00-05:00
 subsection: Web App Plugins

--- a/site/content/extend/plugins/webapp/reference.md
+++ b/site/content/extend/plugins/webapp/reference.md
@@ -1,5 +1,6 @@
 ---
 title: Web App Reference
+heading: "Mattermost Web App Reference"
 description: "Learn how to implement the PluginClass interface used by the Mattermost web app to initialize and uninitialize your plugin."
 date: 2018-07-10T00:00:00-05:00
 subsection: Web App Plugins

--- a/site/content/integrate/examples/_index.md
+++ b/site/content/integrate/examples/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Examples"
+heading: "Examples of Mattemost Integrations"
 description: "Check out some examples of integrations to get a better idea of how you can extend Mattermost."
 date: "2017-01-19T12:01:23-04:00"
 section: "integrate"

--- a/site/content/integrate/getting-started/_index.md
+++ b/site/content/integrate/getting-started/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+heading: "Getting Started with Mattermost"
 description: "Ready to contribute to Mattermost? Learn how to get started building an integration."
 date: "2017-08-19T12:01:23-04:00"
 section: "integrate"

--- a/site/content/integrate/getting-started/how-should-i-integrate.md
+++ b/site/content/integrate/getting-started/how-should-i-integrate.md
@@ -1,5 +1,6 @@
 ---
 title: "How Should I Integrate?"
+heading: "How to Integrate Mattermost"
 description: "Mattermost has various integration points. Learn about the various ways you can integrate Mattermost with other services."
 date: 2017-08-20T12:33:36-04:00
 weight: 1

--- a/site/content/integrate/incoming-webhooks/_index.md
+++ b/site/content/integrate/incoming-webhooks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Incoming Webhooks"
+heading: "Incoming Webhooks at Mattermost"
 description: "Incoming webhooks let you post some data to a Mattermost endpoint to create a message in a channel."
 date: "2017-08-19T12:01:23-04:00"
 section: "integrate"

--- a/site/content/integrate/outgoing-webhooks/_index.md
+++ b/site/content/integrate/outgoing-webhooks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Outgoing Webhooks"
+heading: "Outgoing Webhooks at Mattermost"
 description: "Outgoing webhooks let you receive an event as an HTTP POST when messages get posted into a Mattermost channel."
 date: "2017-08-19T12:01:23-04:00"
 section: "integrate"

--- a/site/content/integrate/rest-api/_index.md
+++ b/site/content/integrate/rest-api/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "API Reference"
+heading: "Mattermost API Reference"
 description: "The Mattermost Web Services API is used by Mattermost clients and third party applications to interact with the server."
 date: "2017-01-19T12:01:23-04:00"
 section: "integrate"

--- a/site/content/integrate/slash-commands/_index.md
+++ b/site/content/integrate/slash-commands/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Slash Commands"
+heading: "Slash Commands at Mattermost"
 description: "Slash commands trigger an HTTP request to a web service that can in turn post one or more messages in response."
 date: "2017-08-19T12:01:23-04:00"
 section: "integrate"

--- a/site/content/internal/infrastructure/_index.md
+++ b/site/content/internal/infrastructure/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Infrastructure
+heading: "Infrastructure at Mattermost"
 description: "Browse this repository to learn about Mattermsot infrastructure and what we use to build our product."
 date: 2017-11-06T19:30:07-05:00
 section: internal

--- a/site/content/internal/infrastructure/aws.md
+++ b/site/content/internal/infrastructure/aws.md
@@ -1,5 +1,6 @@
 ---
 title: AWS
+heading: "Mattermost Infrastructure on AWS"
 description: "The majority of Mattermost's infrastructure is hosted in Amazon Web Services."
 date: 2017-11-06T19:30:07-05:00
 subsection: internal

--- a/site/content/internal/infrastructure/build.md
+++ b/site/content/internal/infrastructure/build.md
@@ -1,5 +1,6 @@
 ---
 title: Build
+heading: "Automated Builds at Mattermost"
 description: "Learn about our automated build processes, most of which currently take place on Jenkins at build.mattermost.com."
 date: 2017-11-20T20:52:46-05:00
 subsection: internal

--- a/site/content/internal/infrastructure/grafana.md
+++ b/site/content/internal/infrastructure/grafana.md
@@ -1,5 +1,6 @@
 ---
 title: "Community Grafana"
+heading: "Community Grafana - Mattermost"
 description: "Grafana runs in the Mattermost Cloud infrastructure in the same cluster that community installations are hosted."
 date: 2020-03-31T20:52:46-05:00
 subsection: internal

--- a/site/content/internal/infrastructure/guidelines.md
+++ b/site/content/internal/infrastructure/guidelines.md
@@ -1,12 +1,13 @@
 ---
 title: Guidelines for New Infrastructure
+heading: "Guidelines for New Infrastructure - Mattermost"
 description: "Building or deploying new infrastructure? Make sure it follows these guidelines."
 date: 2017-11-06T19:30:07-05:00
 subsection: internal
 weight: 100
 ---
 
-# All new infrastructure should meet these requirements.
+## All new infrastructure should meet these requirements.
 
 ### Authentication should be centralized.
 

--- a/site/content/internal/infrastructure/kubernetes/_index.md
+++ b/site/content/internal/infrastructure/kubernetes/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes
+heading: "Kubernetes at Mattermost"
 description: "Learn about the relationship between Mattermost and Kubernetes and how we orchestrate our releases."
 date: 2018-11-06T12:36:58+01:00
 section: internal/infrastructure

--- a/site/content/internal/infrastructure/kubernetes/kubernetes-troubleshooting.md
+++ b/site/content/internal/infrastructure/kubernetes/kubernetes-troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: "Kubernetes Maintenance"
+heading: "Troubleshooting Kubernetes at Mattermost"
 description: "This page helps developers access and perform any type of maintenance in the Production Mattermost Kubernetes Cluster."
 date: 2018-11-07T15:24:42+01:00
 weight: 10

--- a/site/content/internal/infrastructure/onelogin-aws.md
+++ b/site/content/internal/infrastructure/onelogin-aws.md
@@ -1,5 +1,6 @@
 ---
 title: "OneLogin and AWS"
+heading: "OneLogin and AWS at Mattermost"
 description: "Find out how the Mattermost team generates AWS keys using OneLogin authentication."
 date: 2018-11-07T16:10:15+01:00
 weight: 45

--- a/site/content/internal/infrastructure/plugins.md
+++ b/site/content/internal/infrastructure/plugins.md
@@ -1,5 +1,6 @@
 ---
 title: Adding a Plugin to Community
+heading: "Adding a Plugin - Mattermost Community"
 description: "Find out how to add a plugin to the Mattermost community server to share your work."
 date: 2017-11-06T19:30:07-05:00
 subsection: Infrastructure

--- a/site/content/internal/infrastructure/vault.md
+++ b/site/content/internal/infrastructure/vault.md
@@ -1,5 +1,6 @@
 ---
 title: Vault
+heading: "The Purpose of Vault at Mattermost"
 description: "Vault is a high security secret store. At Mattermost, its primary purpose is to sign SSH keys."
 date: 2017-11-06T19:30:07-05:00
 subsection: internal

--- a/site/content/internal/infrastructure/vpn-cloud.md
+++ b/site/content/internal/infrastructure/vpn-cloud.md
@@ -1,5 +1,6 @@
 ---
 title: "VPN(CLOUD)"
+heading: "Setting up VPN Access on Pritunl"
 description: "Learn how to use a VPN service with Mattermost to enjoy additional layers of protection."
 date: 2018-06-05T16:08:19+02:00
 subsection: internal

--- a/site/content/internal/infrastructure/vpn.md
+++ b/site/content/internal/infrastructure/vpn.md
@@ -1,5 +1,6 @@
 ---
 title: "VPN"
+heading: "Setting up VPN Access with Mattermost"
 description: "Find out how to setup VPN access when you are onboarding with Mattermost."
 date: 2018-05-28T16:08:19+02:00
 subsection: internal

--- a/site/content/internal/mobile-build-process/_index.md
+++ b/site/content/internal/mobile-build-process/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Mobile Build Process
+heading: "The Mattermost Mobile Build Process"
 description: "Learn what there is to know about the mobile build process for Mattermost's applications."
 date: 2019-03-14T09:05:00-05:00
 section: internal

--- a/site/content/internal/mobile-build-process/bump-build-number.md
+++ b/site/content/internal/mobile-build-process/bump-build-number.md
@@ -1,5 +1,6 @@
 ---
 title: Bump Build Number
+heading: "Bump Build Number at Mattermost"
 description: "Find out how to bump a build number in your local copy of mattermost-mobile."
 date: 2017-11-07T14:28:35-05:00
 subsection: Mobile Build Process

--- a/site/content/internal/mobile-build-process/bump-version-number.md
+++ b/site/content/internal/mobile-build-process/bump-version-number.md
@@ -1,5 +1,6 @@
 ---
 title: Bump Version Number
+heading: "Bump Version Number at Mattermost"
 description: "Learn how to bump a version number in your local copy of mattermost-mobile."
 date: 2017-11-07T14:28:35-05:00
 subsection: Mobile Build Process

--- a/site/content/internal/mobile-build-process/troubleshooting.md
+++ b/site/content/internal/mobile-build-process/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+heading: "Troubleshooting the Mobile Build Process"
 description: "Having problems with the mobile build process? Give these troubleshooting tips a try."
 date: 2017-11-07T14:28:35-05:00
 subsection: Mobile Build Process

--- a/site/content/internal/offboarding.md
+++ b/site/content/internal/offboarding.md
@@ -1,5 +1,6 @@
 ---
 title: Offboarding
+heading: "Information about Offboarding at Mattermost"
 description: "Is someone leaving Mattermost? Here's a comprehensive list of what needs to be done to ensure successful offboarding."
 date: 2018-03-19T14:59:29-05:00
 section: internal

--- a/site/content/internal/onboarding/_index.md
+++ b/site/content/internal/onboarding/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Onboarding
+heading: "Information about Onboarding at Mattermost"
 description: "Are you starting a new job with Mattermost? Check out these onboarding resources as you settle in."
 date: 2017-11-07T14:28:35-05:00
 section: internal

--- a/site/content/internal/onboarding/manager-guide.md
+++ b/site/content/internal/onboarding/manager-guide.md
@@ -1,5 +1,6 @@
 ---
 title: Manager Guide
+heading: "The Manager's Guide to Onboarding at Mattermost"
 description: "This guide helps managers learn what they need to do to help new hires onboard into Mattermost."
 date: 2017-11-07T14:28:35-05:00
 subsection: Onboarding

--- a/site/content/internal/onboarding/new-staff-guide.md
+++ b/site/content/internal/onboarding/new-staff-guide.md
@@ -1,5 +1,6 @@
 ---
 title: New Staff Guide
+heading: "Onboarding at Mattermost: New Staff Guide"
 description: "Are you new to working at Mattermost? Check out this guide as you begin working here."
 date: 2017-11-07T14:28:35-05:00
 subsection: Onboarding

--- a/site/content/internal/plugin-release-process.md
+++ b/site/content/internal/plugin-release-process.md
@@ -1,5 +1,6 @@
 ---
 title: Plugin Release Process
+heading: "The Mattermost Plugin Release Process"
 description: "Interested in learning about the Mattermost plugin release process? Learn about plugins here."
 date: 2017-11-07T14:28:35-05:00
 section: internal

--- a/site/content/internal/qa/_index.md
+++ b/site/content/internal/qa/_index.md
@@ -1,5 +1,6 @@
 ---
 title: QA
+heading: "Quality Assurance (QA) at Mattermost"
 description: "This repository collects documentation about how the Mattermost team approaches QA."
 date: 2018-06-25T13:31:26+02:00
 section: internal

--- a/site/content/internal/rd-teams.md
+++ b/site/content/internal/rd-teams.md
@@ -1,5 +1,6 @@
 ---
 title: R&D Teams
+heading: "An Introduction to R&D Teams at Mattermost"
 description: "Find out which engineers are working in different R&D departments at Mattermost."
 date: 2019-02-06T14:28:35-05:00
 section: internal

--- a/site/content/internal/release-process.md
+++ b/site/content/internal/release-process.md
@@ -1,5 +1,6 @@
 ---
 title: Release Cutting Process
+heading: "The Mattermost Release Cutting Process"
 description: "This document outlines the Mattermost team's release cutting process for new Mattermost releases."
 date: 2017-11-07T14:28:35-05:00
 section: internal

--- a/site/content/internal/release-tagging-process.md
+++ b/site/content/internal/release-tagging-process.md
@@ -1,5 +1,6 @@
 ---
 title: Release Tagging Process
+heading: "Release Tagging Process at Mattermost"
 description: "Read about the Mattermost release tagging process under our mobile build process."
 date: 2019-05-23T16:02:00-05:00
 section: internal

--- a/site/content/internal/sustained-engineering.md
+++ b/site/content/internal/sustained-engineering.md
@@ -1,5 +1,6 @@
 ---
 title: Sustained Engineering Team
+heading: "What is the Sustained Engineering Team?"
 description: "Learn more about the Sustained Engineering Team (SET), which is responsible for improving and maintaining quality."
 date: 2019-02-06T14:28:35-05:00
 section: internal

--- a/site/content/internal/tips-and-best-practices.md
+++ b/site/content/internal/tips-and-best-practices.md
@@ -1,5 +1,6 @@
 ---
 title: Tips and Best Practices
+heading: "Mattermost - Tips and Best Practices"
 description: "Mattermost takes pride in working with the community and we encourage each Mattermost developer to work with community members."
 date: 2017-11-07T14:28:35-05:00
 section: internal

--- a/site/content/internal/writing-a-blog-post.md
+++ b/site/content/internal/writing-a-blog-post.md
@@ -1,5 +1,6 @@
 ---
 title: Writing a Blog Post
+heading: "Writing a Blog Post at Mattermost"
 description: "Blog posts are a great way to share your experience with the community. Follow these guidelines when writing a blog post for Mattermost."
 date: 2019-02-06T14:28:35-05:00
 section: internal
@@ -63,6 +64,7 @@ The steps below outline the process involved in creating the blog post file from
     ---
     title: <user readable title of your blog post, e.g. My Blog Post>
     description: "<brief description of the post less than 160 characters in length>"
+    heading: "<the heading that appears at the top of the page content>"
     slug: <URL name of your blog post, e.g. my-blog-post>
     date: YYYY-MM-DDT12:00:00-04:00
     author: <FirstName LastName>

--- a/site/layouts/_default/list.html
+++ b/site/layouts/_default/list.html
@@ -17,7 +17,11 @@
                 <div class="col-lg-9 doc-content">
                     {{ partial "page-edit.html" . }}
                     <h1 class="mt-0 doc-title">
-                        {{ .Title }}
+                        {{ if .Params.heading }}
+                            {{ .Params.heading }}
+                        {{ else }}
+                            {{ .Title }}
+                        {{ end }}
                     </h1>
                     {{ partial "hanchor.html" .Content }}
                 </div>

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -17,7 +17,11 @@
                 <div class="col-lg-9 doc-content">
                     {{ partial "page-edit.html" . }}
                     <h1 class="mt-0 doc-title">
-                        {{ .Title }}
+                        {{ if .Params.heading }}
+                            {{ .Params.heading }}
+                        {{ else }}
+                            {{ .Title }}
+                        {{ end }}
                     </h1>
                     {{ partial "hanchor.html" .Content }}
                 </div>

--- a/site/layouts/_default/taxonomy.html
+++ b/site/layouts/_default/taxonomy.html
@@ -14,6 +14,15 @@
         <div class="row">
             <div class="col-md-9 doc-content">
                 <div class="well well-sm">
+
+                    <h1>
+                        {{ range where .Site.Params.categories.item "term" "==" $.Data.Term }}
+                            {{ .heading }}
+                        {{ else }}
+                            {{ .Site.Params.categories.heading }}
+                        {{ end }}
+                    </h1>
+
                     <h2>Items in category <code>{{ .Title | lower }}</code></h2>
                     <ul class="list-unstyled" style="margin-top: 20px">
                         {{ range .Data.Pages }}

--- a/site/layouts/blog/list.html
+++ b/site/layouts/blog/list.html
@@ -13,7 +13,7 @@
     <div class="container">
         <div class="row">
             <div class="col-md-9 doc-content">
-                <h3>Mattermost Developer Blog</h3>
+                <h1>The Mattermost Developer Blog</h1>
                 {{ range (.Paginate .Data.Pages).Pages.ByDate.Reverse }}
                     {{ .Render "summary" }}
                 {{ end }}

--- a/site/layouts/blog/single.html
+++ b/site/layouts/blog/single.html
@@ -17,7 +17,17 @@
             <div class="col-md-9 doc-content">
                 <div class="well well-sm">
                     <div class="blog-item__header">
-                        <div class="blog-item__title">{{ .Title }}<br> <small>{{ .Description }}</small></div>
+                        <div class="blog-item__title">
+                            <h1>
+                            {{ if .Params.heading }}
+                                {{ .Params.heading }}
+                            {{ else }}
+                                {{ .Title }}
+                            {{ end }}
+                            </h1>
+                            <small>{{ .Description }}</small>
+                            
+                        </div>
                         <div class="blog-item__info">
                             {{ .Date.Format "January 2, 2006" }}
                             <small class="blog-item__count">{{ .WordCount }} words</small>

--- a/site/static/css/styles.css
+++ b/site/static/css/styles.css
@@ -3276,6 +3276,11 @@ h6:first-child {
     font-size: 1.5rem;
     margin-bottom: .6rem;
 }
+.blog-item__title h1 {
+    font-size: 1.5rem;
+    line-height: 1.5;
+    margin-bottom: 0;
+}
 
 .blog-item__count {
     margin: 0 0 0 5px;


### PR DESCRIPTION
#### Summary

Per SEO team, H1s are implemented throughout the site using a document property for consistent output on every page.

- Certain pages such as taxonomy pages and indexes that do not have a `.md` file leverage the same system as meta descriptions found in `config.toml`
- A handful of pages had an H1 in the markdown; these were removed for consistency so all pages have an easy to find `heading` property that can be edited.
- The instructions for creating a blog post were updated to include the `heading` property and instructions on how to use it.

#### Ticket Link

https://mattermost.atlassian.net/browse/MAR-221

