### PR TITLE
REST API Docs: Fix syntax error in Go code sample and indent

### DIFF
--- a/site/content/contribute/server/rest-api.md
+++ b/site/content/contribute/server/rest-api.md
@@ -63,17 +63,16 @@ To implement the API handler you'll first need to [setup your developer environm
     - The general pattern for handlers is
 
         ```Go
-        func handlerName(c *Context, w http.ResponseWriter, r *\ http.Request) {
+        func handlerName(c *Context, w http.ResponseWriter, r *http.Request) {
+            // 1. Parsing of request URL and body
 
-        // 1. Parsing of request URL and body
+            // 2. Permissions check if required
 
-        // 2. Permissions check if required
+            // 3. Invoke logic through the app package
 
-        // 3. Invoke logic through the app package
+            // 4. (Optional) Check the Etag
 
-        // 4. (Optional) Check the Etag
-
-        // 5. Format the response and write the response
+            // 5. Format the response and write the response
         }
         ```
 


### PR DESCRIPTION
Hey, first time committer here (starting my new job at MatterMost from March, but already warming up).

#### Summary
I noticed a syntactical error in the Go example on adding API endpoints, this fixes it. Bonus: it indents the comments.

#### Ticket Link
No ticket, didn't seem worth it since it's a trivial fix.