### PR TITLE
Replaced inline 3rd-party snippets with GTM container

### DIFF
--- a/site/layouts/_default/list.html
+++ b/site/layouts/_default/list.html
@@ -9,6 +9,7 @@
         {{ partial "head.html" .}}
     </head>
 <body>
+    {{ partial "gtm-body-noscript.html" }}
     {{ partial "nav2.html" .}}
     <div id="wrapper">
         <div class="container-fluid">

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -9,6 +9,7 @@
         {{ partial "head.html" .}}
     </head>
 <body>
+    {{ partial "gtm-body-noscript.html" }}
     {{ partial "nav2.html" .}}
     <div id="wrapper">
         <div class="container-fluid">

--- a/site/layouts/_default/taxonomy.html
+++ b/site/layouts/_default/taxonomy.html
@@ -9,6 +9,7 @@
         {{ partial "head.html" .}}
     </head>
 <body>
+    {{ partial "gtm-body-noscript.html" }}
     {{ partial "nav2.html" .}}
     <div class="container">
         <div class="row">

--- a/site/layouts/blog/list.html
+++ b/site/layouts/blog/list.html
@@ -9,6 +9,7 @@
         {{ partial "head.html" .}}
     </head>
 <body class="blog-list">
+    {{ partial "gtm-body-noscript.html" }}
     {{ partial "nav2.html" .}}
     <div class="container">
         <div class="row">

--- a/site/layouts/blog/single.html
+++ b/site/layouts/blog/single.html
@@ -11,6 +11,7 @@
 </head>
 
 <body class="blog-single">
+    {{ partial "gtm-body-noscript.html" }}
     {{ partial "nav2.html" .}}
     <div class="container">
         <div class="row">

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -8,6 +8,7 @@
         {{ partial "head.html" .}}
     </head>
     <body class="homepage">
+        {{ partial "gtm-body-noscript.html" }}
         {{ partial "nav.html" .}}
 
         <div id="wrapper">

--- a/site/layouts/indexes/tag.html
+++ b/site/layouts/indexes/tag.html
@@ -9,6 +9,7 @@
         {{ partial "head.html" .}}
     </head>
 <body>
+    {{ partial "gtm-body-noscript.html" }}
     {{ partial "nav2.html" .}}
     <div class="container">
         <div class="row">

--- a/site/layouts/partials/gtm-body-noscript.html
+++ b/site/layouts/partials/gtm-body-noscript.html
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-53S4TVZ"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -49,49 +49,11 @@
 <link rel="stylesheet" href="{{ "css/note.css" | absURL }}">
 
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script async src="//cdn.bizible.com/scripts/bizible.js"></script>
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-64458817-2"></script>
-<script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-64458817-2');
-</script>
 
-<!-- Marketo Munchkin Tracking code for Marketing Team -->
-<script type="text/javascript">
-    (function() {
-    var didInit = false;
-    function initMunchkin() {
-    if(didInit === false) {
-    didInit = true;
-    Munchkin.init('161-FBE-733');
-    }
-    }
-    var s = document.createElement('script');
-    s.type = 'text/javascript';
-    s.async = true;
-    s.src = '//munchkin.marketo.net/munchkin.js';
-    s.onreadystatechange = function() {
-    if (this.readyState == 'complete' || this.readyState == 'loaded') {
-    initMunchkin();
-    }
-    };
-    s.onload = initMunchkin;
-    document.getElementsByTagName('head')[0].appendChild(s);
-    })();
-</script>
-
-<!-- Engagio Tracking code for Marketing Team -->
-<script type="text/javascript" charset="utf-8">
-    var _eiq = _eiq || [];
-    var _engagio_settings = {
-      accountId: "cb6a404b72e9141b70d1f82abc04db92b4e56238"
-    };
-    (function() {
-      var ei = document.createElement('script'); ei.type = 'text/javascript'; ei.async = true;
-      ei.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'web-analytics.engagio.com/js/ei.js';
-      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ei, s);
-    })();
-  </script>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-53S4TVZ');</script>
+<!-- End Google Tag Manager -->


### PR DESCRIPTION

The snippets that were baked into the `head.html` partial have been moved to a GTM container for developers.mattermost.com. That GTM container snippet has been added to the `head.html` and the `<noscript>` fallback has been added to all html layouts.

#### Ticket Link
https://mattermost.atlassian.net/browse/MAR-225
