### PR TITLE
Update contribution-checklist.md

### DIFF
--- a/site/content/contribute/getting-started/code-review.md
+++ b/site/content/contribute/getting-started/code-review.md
@@ -69,6 +69,7 @@ If you are a core committer seeking a review
     * [Wait](#if-you-are-awaiting-a-review) for their review to complete before continuing so as to avoid churn if changes are requested.
     * Remove the `2: Dev Review` label only when these reviews are done and they accept the changes.
 7. After Dev review, assign a [QA tester](/contribute/getting-started/core-committers/#qa-testers).
+    * Ensure that your PR includes test steps or expected results for QA reference if the QA Test Steps in the Jira ticket have not already been filled in.
     * The choice of QA tester is up to you.
         - In most cases, choose the QA tester embedded with your team.
         - If your change primarily touches another team's codebase, consider their QA tester.

--- a/site/content/contribute/getting-started/contribution-checklist.md
+++ b/site/content/contribute/getting-started/contribution-checklist.md
@@ -28,6 +28,7 @@ Follow this checklist for submitting a pull request (PR):
 6. The PR title begins with the Jira or GitHub Ticket ID (e.g. `[MM-394]` or `[GH-394]`) and summary template is filled out.
 7. If your PR adds or changes a RESTful API endpoint, please update the [API documentation](https://github.com/mattermost/mattermost-api-reference).
 8. If your PR adds a new plugin API method or hook, please add an example to the [Plugin Starter Template](https://github.com/mattermost/mattermost-plugin-starter-template).
+8. If QA review is applicable, your PR includes test steps or expected results.
 9. Your PR includes basic documentation about the change/addition you're submitting. View our [guidelines](https://handbook.mattermost.com/operations/operations/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/submitting-documentation-with-your-pr) for more information about submitting documentation and the review process.
 
 Once submitted, the automated build process must pass in order for the PR to be accepted. Any errors or failures need to be addressed in order for the PR to be accepted. Next, the PR goes through [code review](https://developers.mattermost.com/contribute/getting-started/code-review/). To learn about the review process for each project, read the `CONTRIBUTING.md` file of that GitHub repository. 

--- a/site/content/contribute/getting-started/contribution-checklist.md
+++ b/site/content/contribute/getting-started/contribution-checklist.md
@@ -28,8 +28,8 @@ Follow this checklist for submitting a pull request (PR):
 6. The PR title begins with the Jira or GitHub Ticket ID (e.g. `[MM-394]` or `[GH-394]`) and summary template is filled out.
 7. If your PR adds or changes a RESTful API endpoint, please update the [API documentation](https://github.com/mattermost/mattermost-api-reference).
 8. If your PR adds a new plugin API method or hook, please add an example to the [Plugin Starter Template](https://github.com/mattermost/mattermost-plugin-starter-template).
-8. If QA review is applicable, your PR includes test steps or expected results.
-9. Your PR includes basic documentation about the change/addition you're submitting. View our [guidelines](https://handbook.mattermost.com/operations/operations/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/submitting-documentation-with-your-pr) for more information about submitting documentation and the review process.
+9. If QA review is applicable, your PR includes test steps or expected results.
+10. Your PR includes basic documentation about the change/addition you're submitting. View our [guidelines](https://handbook.mattermost.com/operations/operations/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/submitting-documentation-with-your-pr) for more information about submitting documentation and the review process.
 
 Once submitted, the automated build process must pass in order for the PR to be accepted. Any errors or failures need to be addressed in order for the PR to be accepted. Next, the PR goes through [code review](https://developers.mattermost.com/contribute/getting-started/code-review/). To learn about the review process for each project, read the `CONTRIBUTING.md` file of that GitHub repository. 
 


### PR DESCRIPTION
I've heard feedback from QA that devs are not always adding QA steps or expected results when they submit a PR, and then QA needs to go after the devs to find out the test steps. Having the test steps ready saves dev and QA time.

I'm updating the docs to add reminders for devs to add QA test steps to PRs (if the test steps are not already listed in the Jira ticket). Additionally we could also add a note about this to the PR Templates in the different repos.

In the past we tried to make it so that test steps would be required to be added when moving a Jira ticket to "PR Submitted", but it caused some issue with the Jira flow https://community.mattermost.com/core/pl/dnh9ibw56fypzbj9n3imybo41h. Also, not all tickets/PRs need QA testing.