### PR TITLE
Update core-committers.md

### DIFF
--- a/site/content/contribute/getting-started/core-committers.md
+++ b/site/content/contribute/getting-started/core-committers.md
@@ -24,7 +24,7 @@ Below is the list of core committers working on Mattermost:
     - Dev areas: Performance, Security, Build, LDAP, Load Tests, Webpack, Permissions, Kubernetes
 - **<a name="harrison.healey">Harrison Healey</a>**
     - @harrison on [community.mattermost.com](https://community.mattermost.com/core/messages/@harrison) and [@hmhealey](https://github.com/hmhealey) on GitHub
-    - Dev areas: Mobile / Desktop and Web apps
+    - Dev areas: Mobile/Desktop and Web apps
 - **<a name="elias.nahum">Elias Nahum</a>**
     - @elias on [community.mattermost.com](https://community.mattermost.com/core/messages/@elias) and [@enahum](https://github.com/enahum) on GitHub
     - Dev areas: Mobile
@@ -41,7 +41,7 @@ Below is the list of core committers working on Mattermost:
     - Dev areas: REST API, WebSocket Events, Kubernetes, Infrastructure, Build/Releases
 - **<a name="martin.kraft">Martin Kraft</a>**
     - @martin.kraft on [community.mattermost.com](https://community.mattermost.com/core/messages/@martin.kraft) and [@mkraft](https://github.com/mkraft) on GitHub
-    - Dev areas: Permissions, Compliance, LDAP
+    - Dev areas: Permissions, Compliance, LDAP, Groups, Data Retention
 - **<a name="jesús.espino">Jesús Espino</a>**
     - @jesus.espino on [community.mattermost.com](https://community.mattermost.com/core/messages/@jesus.espino) and [@jespino](https://github.com/jespino) on GitHub
     - Dev areas: Web App, Permissions, Compliance, Redux, CLI, System Console, Sample Data
@@ -92,7 +92,7 @@ Below is the list of core committers working on Mattermost:
     - Dev areas: Desktop/Web and Mobile apps
 - **<a name="guillermo.vaya">Guillermo Vayá</a>**
     - @guillermo.vaya on [community.mattermost.com](https://community.mattermost.com/core/messages/@guillermo.vaya) and [@Willyfrog](https://github.com/Willyfrog) on GitHub
-    - Dev areas: Web / Desktop apps
+    - Dev areas: Web/Desktop apps
 - **<a name="shota.gvinepadze">Shota Gvinepadze</a>**
     - @shota.gvinepadze on [community.mattermost.com](https://community.mattermost.com/core/messages/@shota.gvinepadze) and [@iomodo](https://github.com/iomodo) on GitHub
     - Dev areas: Toolkit, Plugins, AI, Machine Learning
@@ -143,7 +143,7 @@ Below is the list of core committers working on Mattermost:
     - Dev areas: Extensions
 - **<a name="caleb.roseland">Caleb Roseland</a>**
     - @caleb.roseland on [community.mattermost.com](https://community.mattermost.com/core/messages/@caleb.roseland) and [@calebroseland](https://github.com/calebroseland) on GitHub
-    - Dev areas: Desktop / Web apps
+    - Dev areas: Desktop/Web apps
 - **<a name="avasconcelos114">Andre Vasconcelos</a>**
     - @avasconcelos114 on [community.mattermost.com](https://community.mattermost.com/core/messages/@avasconcelos114) and [@avasconcelos114](https://github.com/avasconcelos114) on GitHub
     - Dev areas: Web App, Mobile Apps
@@ -156,7 +156,9 @@ Below is the list of core committers working on Mattermost:
 - **<a name="avinash.lingaloo">Avinash Lingaloo</a>**
     - @avinash.lingaloo on [community.mattermost.com](https://community.mattermost.com/core/messages/@avinash.lingaloo) and [@avinashlng1080](https://github.com/avinashlng1080) on GitHub
     - Dev areas: Mobile
- 
+- **<a name="collin.eng">Collin Eng</a>**
+    - @collin.eng on [community.mattermost.com](https://community.mattermost.com/core/messages/@collin.eng) and [@engineereng](https://github.com/engineereng) on GitHub
+    - Dev areas: TBD
 
 Core Developers
 ---------------
@@ -251,7 +253,7 @@ Security Engineers
     - Dev areas: Security
 
 Technical Writers
---------------------
+-----------------
 
 The core team also has technical writers who document product features and functionality from release to release, along with product managers. They are:
 

--- a/site/content/contribute/getting-started/core-committers.md
+++ b/site/content/contribute/getting-started/core-committers.md
@@ -50,7 +50,7 @@ Below is the list of core committers working on Mattermost:
     - Dev areas: Performance, Web App, Database, Toolkit
 - **<a name="sudheer.timmaraju">Sudheer Timmaraju</a>**
     - @sudheerdev on [community.mattermost.com](https://community.mattermost.com/core/messages/@sudheerdev) and [@sudheerDev](https://github.com/sudheerDev) on GitHub
-    - Dev areas: Web / Desktop and Mobile apps
+    - Dev areas: Web/Desktop and Mobile apps
 - **<a name="hyeseong.kim">Hyeseong Kim</a>**
     - @cometkim on [community.mattermost.com](https://community.mattermost.com/core/messages/@cometkim) and [@cometkim](https://github.com/cometkim) on GitHub
     - Dev areas: Web App, React, Redux, REST API
@@ -65,7 +65,7 @@ Below is the list of core committers working on Mattermost:
     - Dev areas: Desktop app, Plugins
 - **<a name="dean.whillier">Dean Whillier</a>**
     - @deanwhillier on [community.mattermost.com](https://community.mattermost.com/core/messages/@deanwhillier) and [@deanwhillier](https://github.com/deanwhillier) on GitHub
-    - Dev areas: Desktop / Web and Mobile apps
+    - Dev areas: Desktop/Web and Mobile apps
 - **<a name="miguel.alatzar">Miguel Alatzar</a>**
     - @miguel.alatzar on [community.mattermost.com](https://community.mattermost.com/core/messages/@miguel.alatzar) and [@migbot](https://github.com/migbot) on GitHub
     - Dev areas: Mobile
@@ -95,7 +95,7 @@ Below is the list of core committers working on Mattermost:
     - Dev areas: Toolkit, Plugins, Web App
 - **<a name="devin.binnie">Devin Binnie</a>**
     - @devin.binnie on [community.mattermost.com](https://community.mattermost.com/core/messages/@devin.binnie) and [@devinbinnie](https://github.com/devinbinnie) on GitHub
-    - Dev areas: Desktop / Web and Mobile apps
+    - Dev areas: Desktop/Web and Mobile apps
 - **<a name="guillermo.vaya">Guillermo Vayá</a>**
     - @guillermo.vaya on [community.mattermost.com](https://community.mattermost.com/core/messages/@guillermo.vaya) and [@Willyfrog](https://github.com/Willyfrog) on GitHub
     - Dev areas: Web / Desktop apps
@@ -129,9 +129,6 @@ Below is the list of core committers working on Mattermost:
 - **<a name="chris.overton">Chris Overton</a>**
     - @chris.overton on [community.mattermost.com](https://community.mattermost.com/core/messages/@chris.overton) and [@chris-overton](https://github.com/chris-overton) on GitHub
     - Dev areas: Cloud, Elasticsearch, REST API, Kubernetes
-- **<a name="gabriel.sagula">Gabriel Sagula</a>**
-    - @gabriel.sagula on [community.mattermost.com](https://community.mattermost.com/core/messages/@gabriel.sagula) and [@gsagula](https://github.com/gsagula) on GitHub
-    - Dev areas: Kubernetes, Cloud
 - **<a name="amit.uttam">Amit Uttam</a>**
     - @amit.uttam on [community.mattermost.com](https://community.mattermost.com/core/messages/@amit.uttam) and [@chuttam](https://github.com/chuttam) on GitHub
     - Dev areas: Mobile
@@ -200,10 +197,8 @@ Below is the list of community moderators who share feedback and answer question
 Product Managers
 ----------------
 
-The core team also has product managers who do a lot of great work designing, prioritizing and coordinating. They are:
+The core team also has Product Managers who do a lot of great work designing, prioritizing and coordinating. They are:
 
-- **<a name="lindsay.brock">Lindsay Brock</a>**
-    - @lindsay on [community.mattermost.com](https://community.mattermost.com/core/messages/@lindsay) and [@lfbrock](https://github.com/lfbrock) on GitHub
 - **<a name="jason.blais">Jason Blais</a>**
     - @jason on [community.mattermost.com](https://community.mattermost.com/core/messages/@jason) and [@jasonblais](https://github.com/jasonblais) on GitHub
 - **<a name="eric.sethna">Eric Sethna</a>**
@@ -212,12 +207,6 @@ The core team also has product managers who do a lot of great work designing, pr
     - @katie.wiersgalla on [community.mattermost.com](https://community.mattermost.com/core/messages/@katie.wiersgalla) and [@wiersgallak](https://github.com/wiersgallak) on GitHub
 - **<a name="aaron.rothschild">Aaron Rothschild</a>**
     - @aaron.rothschild on [community.mattermost.com](https://community.mattermost.com/core/messages/@aaron.rothschild) and [@aaronrothschild](https://github.com/aaronrothschild) on GitHub
-- **<a name="dennis.kittrell">Dennis Kittrell</a>**
-    - @dennis.kittrell on [community.mattermost.com](https://community.mattermost.com/core/messages/@dennis.kittrell) and [@thefactremains](https://github.com/thefactremains) on GitHub
-- **<a name="eric.sadur">Eric Sadur</a>**
-    - @eric.sadur on [community.mattermost.com](https://community.mattermost.com/core/messages/@eric.sadur) and [@etoaster](https://github.com/etoaster) on GitHub
-- **<a name="adam.clarkson">Adam Clarkson</a>**
-    - @adam.clarkson on [community.mattermost.com](https://community.mattermost.com/core/messages/@adam.clarkson) and [@adamjclarkson](https://github.com/adamjclarkson) on GitHub
 - **<a name="ian.tao">Ian Tao</a>**
     - @tao on [community.mattermost.com](https://community.mattermost.com/core/messages/@tao) and [@itao](https://github.com/itao) on GitHub
 
@@ -244,8 +233,6 @@ The core team also has QA testers who verify the correct functionality of the pr
     - @ogi.marusic on [community.mattermost.com](https://community.mattermost.com/core/messages/@ogi.marusic) and [@ogi-m](https://github.com/ogi-m) on GitHub
 - **<a name="prapti.shrestha">Prapti Shrestha</a>**
     - @prapti.shrestha on [community.mattermost.com](https://community.mattermost.com/core/messages/@prapti.shrestha) and [@prapti](https://github.com/prapti) on GitHub
-- **<a name="rohitesh.gupta">Rohitesh Gupta</a>**
-    - @rohitesh.gupta on [community.mattermost.com](https://community.mattermost.com/core/messages/@rohitesh.gupta) and [@srkgupta](https://github.com/srkgupta) on GitHub
 - **<a name="jelena.gilliam">Jelena Gilliam</a>**
     - @jelena.gilliam on [community.mattermost.com](https://community.mattermost.com/core/messages/@jelena.gilliam) and [@jgilliam17](https://github.com/jgilliam17) on GitHub
 - **<a name="steve.mudie">Steve Mudie</a>**
@@ -254,15 +241,13 @@ The core team also has QA testers who verify the correct functionality of the pr
     - @joseph.baylon on [community.mattermost.com](https://community.mattermost.com/core/messages/@joseph.baylon) and [@josephbaylon](https://github.com/josephbaylon) on GitHub
 
 Build Engineers
---------------------
+---------------
 
 - **<a name="elisabeth.kulzer">Elisabeth Kulzer</a>**
     - @elisabeth.kulzer on [community.mattermost.com](https://community.mattermost.com/core/messages/@elisabeth.kulzer) and [@metanerd](https://github.com/metanerd) on GitHub
-- **<a name="jason.deland">Jason Deland</a>**
-    - @jason.deland on [community.mattermost.com](https://community.mattermost.com/core/messages/@jason.deland) and [@jaydeland](https://github.com/jaydeland) on GitHub
     
 Security Engineers
---------------------    
+------------------    
 
 - **<a name="daniel.schalla">Daniel Schalla</a>**
     - @dschalla on [community.mattermost.com](https://community.mattermost.com/core/messages/@dschalla) and [@dschalla](https://github.com/dschalla) on GitHub
@@ -273,6 +258,9 @@ Security Engineers
 - **<a name="corey.robinson">Corey Robinson</a>**
     - @corey.robinson on [community.mattermost.com](https://community.mattermost.com/core/messages/@corey.robinson) and [@corey-robinson](https://github.com/corey-robinson) on GitHub
     - Dev areas: Security
+- **<a name="rohitesh.gupta">Rohitesh Gupta</a>**
+    - @rohitesh.gupta on [community.mattermost.com](https://community.mattermost.com/core/messages/@rohitesh.gupta) and [@srkgupta](https://github.com/srkgupta) on GitHub
+    - Dev areas: Security
 
 Technical Writers
 --------------------
@@ -281,6 +269,8 @@ The core team also has technical writers who document product features and funct
 
 - **<a name="justine.geffen">Justine Geffen</a>**
     - @justine.geffen on [community.mattermost.com](https://community.mattermost.com/core/messages/@justine.geffen) and [@justinegeffen](https://github.com/justinegeffen) on GitHub
+- **<a name="carrie.warner">Carrie Warner</a>**
+    - @carrie.warner on [community.mattermost.com](https://community.mattermost.com/core/messages/@carrie.warner) and [@cwarnermm](https://github.com/cwarnermm) on GitHub
 
 How to promote a contributor to core committer
 -----------------------------------------------

--- a/site/content/contribute/getting-started/core-committers.md
+++ b/site/content/contribute/getting-started/core-committers.md
@@ -48,9 +48,6 @@ Below is the list of core committers working on Mattermost:
 - **<a name="jesse.hallam">Jesse Hallam</a>**
     - @jesse.hallam on [community.mattermost.com](https://community.mattermost.com/core/messages/@jesse.hallam) and [@lieut-data](https://github.com/lieut-data) on GitHub
     - Dev areas: Performance, Web App, Database, Toolkit
-- **<a name="sudheer.timmaraju">Sudheer Timmaraju</a>**
-    - @sudheerdev on [community.mattermost.com](https://community.mattermost.com/core/messages/@sudheerdev) and [@sudheerDev](https://github.com/sudheerDev) on GitHub
-    - Dev areas: Web/Desktop and Mobile apps
 - **<a name="hyeseong.kim">Hyeseong Kim</a>**
     - @cometkim on [community.mattermost.com](https://community.mattermost.com/core/messages/@cometkim) and [@cometkim](https://github.com/cometkim) on GitHub
     - Dev areas: Web App, React, Redux, REST API
@@ -87,9 +84,6 @@ Below is the list of core committers working on Mattermost:
 - **<a name="michael.kochell">Michael Kochell</a>**
     - @michael.kochell on [community.mattermost.com](https://community.mattermost.com/core/messages/@michael.kochell) and [@mickmister](https://github.com/mickmister) on GitHub
     - Dev areas: Extensions
-- **<a name="ali.farooq">Ali Farooq</a>**
-    - @ali.farooq on [community.mattermost.com](https://community.mattermost.com/core/messages/@ali.farooq) and [@ali-farooq0](https://github.com/ali-farooq0) on GitHub
-    - Dev areas: Toolkit, Plugins, Server, Clustering
 - **<a name="maria.nunez">Maria Nuñez</a>**
     - @maria.nunez on [community.mattermost.com](https://community.mattermost.com/core/messages/@maria.nunez) and [@marianunez](https://github.com/marianunez) on GitHub
     - Dev areas: Toolkit, Plugins, Web App
@@ -102,9 +96,6 @@ Below is the list of core committers working on Mattermost:
 - **<a name="shota.gvinepadze">Shota Gvinepadze</a>**
     - @shota.gvinepadze on [community.mattermost.com](https://community.mattermost.com/core/messages/@shota.gvinepadze) and [@iomodo](https://github.com/iomodo) on GitHub
     - Dev areas: Toolkit, Plugins, AI, Machine Learning
-- **<a name="eli.yukelzon">Eli Yukelzon</a>**
-    - @eli.yukelzon on [community.mattermost.com](https://community.mattermost.com/core/messages/@eli.yukelzon) and [@reflog](https://github.com/reflog) on GitHub
-    - Dev areas: Load Tests, Performance, Guest Accounts, Typescript
 - **<a name="claudio.costa">Claudio Costa</a>**
     - @claudio.costa on [community.mattermost.com](https://community.mattermost.com/core/messages/@claudio.costa) and [@streamer45](https://github.com/streamer45) on GitHub
     - Dev areas: Server, Load Tests, Performance, Race Conditions, Multimedia
@@ -135,9 +126,6 @@ Below is the list of core committers working on Mattermost:
 - **<a name="doug.lauder">Doug Lauder</a>**
     - @doug.lauder on [community.mattermost.com](https://community.mattermost.com/core/messages/@doug.lauder) and [@wiggin77](https://github.com/wiggin77) on GitHub
     - Dev areas: TBA
-- **<a name="farhan.munshi">Farhan Munshi</a>**
-    - @farhan.munshi on [community.mattermost.com](https://community.mattermost.com/core/messages/@farhan.munshi) and [@fm2munsh](https://github.com/fm2munsh) on GitHub
-    - Dev areas: Permissions, Compliance, LDAP
 - **<a name="ibrahim.acikgoz">Ibrahim Acikgoz</a>**
     - @ibrahim.acikgoz on [community.mattermost.com](https://community.mattermost.com/core/messages/@ibrahim.acikgoz) and [@isacikgoz](https://github.com/isacikgoz) on GitHub
     - Dev areas: Backend, CLI, Performance

--- a/site/content/internal/rd-teams.md
+++ b/site/content/internal/rd-teams.md
@@ -16,14 +16,17 @@ weight: 110
 ### Messaging
 
 #### Leadership
+
 * Joram Wilander - Senior Engineering Lead
 * Katie Wiersgalla - Senior Product Manager Lead
 
 #### Product Managers
+
 * Eric Sethna - Product Manager
 * Aaron Rothschild - Product Manager
 
 #### Full Stack 1 (name TBD)
+
 * Catalin Tomai - Engineering Lead
 * Martin Kraft - Engineer
 * Claudio Costa - Engineer
@@ -32,6 +35,7 @@ weight: 110
 * Furqan Malik - SDET
 
 #### Full Stack 2 (name TBD)
+
 * Catalin Tomai - Engineering Lead
 * Lev Brouk - Engineer
 * Michael Kochell - Engineer
@@ -42,6 +46,7 @@ weight: 110
 * Matt Birtch - UX Designer
 
 #### Full Stack 3 (name TBD)
+
 * Joram Wilander - Engineering Lead
 * Ashish Bhate - Engineer
 * Anurag Shivarathri - Engineer
@@ -49,6 +54,7 @@ weight: 110
 * Jelena Gilliam - QA
 
 #### Web Platform
+
 * Joram Wilander - Engineering Lead
 * Harrison Healey - Engineer
 * Devin Binnie - Engineer
@@ -56,6 +62,7 @@ weight: 110
 * Jelena Gilliam - QA
 
 #### Suite Platform
+
 * Joram Wilander - Engineering Lead
 * Agniva De Sarker - Engineer
 * Ibrahim Acikgoz - Engineer
@@ -88,6 +95,7 @@ weight: 110
 ### Cloud
 
 #### Leadership
+
 * Jason Blais - Senior Product Manager Lead
 
 ### Cloud Features Team
@@ -106,7 +114,6 @@ weight: 110
 * Gabe Jackson - Engineering Lead
 * Ian Whitlock - Engineer
 * Szymon Gibała - Engineer
-* Adam Clarkson - Product Manager
 
 ## Site Reliability Engineering Team
 
@@ -125,6 +132,7 @@ weight: 110
 ### Platform Teams
 
 #### Leadership
+
 * Zef Hemel - Engineering Lead
 * Jason Blais - Senior Product Manager Lead
 
@@ -143,6 +151,7 @@ weight: 110
 * Lindy Isherwood - QA
 
 #### UI Team
+
 * Dean Whillier - Engineering Lead
 * Nevy Angelova - Engineer
 * Michel Engelen - Engineer
@@ -157,5 +166,6 @@ weight: 110
 * Katie Wiersgalla - Product Manager
 
 ## Docs
+
+* Carrie Warner - Senior Technical Writer
 * Justine Geffen - Technical Writer
-* Carrie Warner - Technical Writer

--- a/site/content/internal/rd-teams.md
+++ b/site/content/internal/rd-teams.md
@@ -25,6 +25,10 @@ weight: 110
 * Eric Sethna - Product Manager
 * Aaron Rothschild - Product Manager
 
+#### Technical Writers
+
+* Carrie Warner - Senior Technical Writer
+
 #### Full Stack 1 (name TBD)
 
 * Catalin Tomai - Engineering Lead
@@ -59,7 +63,6 @@ weight: 110
 * Harrison Healey - Engineer
 * Devin Binnie - Engineer
 * Guillermo Vaya - Engineer
-* Jelena Gilliam - QA
 
 #### Suite Platform
 
@@ -91,6 +94,7 @@ weight: 110
 * Ogi Marusic - QA
 * Chen-I Lim - Product Manager
 * Michael Gamble - UX Designer
+* Justine Geffen - Technical Writer
 
 ### Cloud
 
@@ -98,7 +102,7 @@ weight: 110
 
 * Jason Blais - Senior Product Manager Lead
 
-### Cloud Features Team
+### Growth Team
 
 * Maria Nuñez - Engineering Lead
 * Allan Guwatudde - Engineer
@@ -107,7 +111,7 @@ weight: 110
 * Nick Misasi - Engineer
 * Steve Mudie - QA
 * Anneliese Klein - UX Designer
-* Carrie Warner - Technical Writer
+* Justine Geffen - Technical Writer
 
 ### Cloud Platform Team
 
@@ -125,7 +129,8 @@ weight: 110
 
 ## Release/DevOps Team
 
-* Carlos Panato - Engineer, Tech Lead
+* Joram Wilander - Engineering Lead
+* Carlos Panato - Engineer
 * Elisabeth Kulzer - Engineer
 * Amy Blais - Release Manager
 
@@ -142,7 +147,6 @@ weight: 110
 * Miguel Alatzar - Engineer
 * Avinash Lingaloo - Engineer
 * Joseph Baylon - QA SDET
-* Eric Sethna - Product Manager
 
 #### QA Team
 
@@ -164,8 +168,3 @@ weight: 110
 * Corey Robinson - Security Engineer, Infrastructure & Operations
 * Kennedy Torkura - Cloud Security Engineer
 * Katie Wiersgalla - Product Manager
-
-## Docs
-
-* Carrie Warner - Senior Technical Writer
-* Justine Geffen - Technical Writer

--- a/site/content/internal/rd-teams.md
+++ b/site/content/internal/rd-teams.md
@@ -10,7 +10,6 @@ weight: 110
 
 * Corey Hulen - CTO
 * Chris Overton - VP Engineering
-* Chandar Venkataraman - CPO
 
 ## Feature Teams
 
@@ -31,9 +30,7 @@ Feature teams are full-stack teams owning collections of features within the Mat
 
 * Scott Bishel - Engineering Lead
 * Jesus Espino - Engineer
-* Eli Yukelzon - Engineer
 * Ashish Bhate - Engineer
-* Caleb Roseland - Engineer
 * Ogi Marusic - QA
 * Eric Sethna - Product Manager
 * Andrew Brown - UX Designer
@@ -45,12 +42,10 @@ Feature teams are full-stack teams owning collections of features within the Mat
 * Lev Brouk - Engineer
 * Jason Frerich - Engineer
 * Michael Kochell - Engineer
-* Shota Gvinepadze - Engineer
 * Ben Schumacher - Engineer
 * Daniel Espino Garcia - Engineer
 * Dylan Haussermann - QA
 * Aaron Rothschild - Product Manager
-* Abhijit Singh - UX Designer
 * Justine Geffen - Technical Writer
 
 ### Workflows Team
@@ -59,9 +54,11 @@ Feature teams are full-stack teams owning collections of features within the Mat
 * Christopher Speller - Engineer
 * Christopher Poile - Engineer
 * Alejandro García Montoro - Engineer
+* Caleb Roseland - Engineer
+* Shota Gvinepadze - Engineer
 * Prapti Shrestha - QA SDET
 * Ian Tao - Product Manager
-* Alex Siclari - UX Designer
+* Abhijit Singh - UX Designer
 * Justine Geffen - Technical Writer
 
 ### Cloud Features Team
@@ -94,7 +91,6 @@ Platform Teams are focused on an individual technical specialisation or layer of
 
 * Dean Whillier - Engineering Lead
 * Harrison Healey - Engineer
-* Sudheer Timmaraju - Engineer
 * Devin Binnie - Engineer
 * Guillermo Vayá - Engineer
 * Nevy Angelova - Engineer
@@ -137,7 +133,6 @@ Platform Teams are focused on an individual technical specialisation or layer of
 
 * Jason Deland - Engineering Lead
 * Elisabeth Kulzer - Build Engineer
-* Khosrow Moossavi - Build Engineer
 
 ## Security Team
 

--- a/site/content/internal/rd-teams.md
+++ b/site/content/internal/rd-teams.md
@@ -8,47 +8,59 @@ weight: 110
 
 ## Leadership
 
-* Corey Hulen - CTO
+* Corey Hulen - CTO, Head of Product
 * Chris Overton - VP Engineering
 
-## Feature Teams
+## Verticals
 
-Feature teams are full-stack teams owning collections of features within the Mattermost product.
+### Messaging
 
-### Enterprise Features Team
+#### Leadership
+* Joram Wilander - Senior Engineering Lead
+* Katie Wiersgalla - Senior Product Manager Lead
 
-* Scott Bishel - Engineering Lead
-* Martin Kraft - Engineeer
-* Hossein Ahmadian - Engineer
-* Anurag Shivarathri - Engineer
-* Furqan Malik - QA SDET
-* Katie Wiersgalla - Product Manager
-* Michael Gamble - UX Designer
-* Carrie Warner - Technical Writer
-
-### Core Features Team
-
-* Scott Bishel - Engineering Lead
-* Jesus Espino - Engineer
-* Ashish Bhate - Engineer
-* Ogi Marusic - QA
+#### Product Managers
 * Eric Sethna - Product Manager
-* Andrew Brown - UX Designer
-* Carrie Warner - Technical Writer
+* Aaron Rothschild - Product Manager
 
-### Integrations Team
+#### Full Stack 1 (name TBD)
+* Catalin Tomai - Engineering Lead
+* Martin Kraft - Engineer
+* Claudio Costa - Engineer
+* Shaz Amjad - Engineer
+* Benjamin Cooke - Engineer
+* Furqan Malik - SDET
 
+#### Full Stack 2 (name TBD)
 * Catalin Tomai - Engineering Lead
 * Lev Brouk - Engineer
-* Jason Frerich - Engineer
 * Michael Kochell - Engineer
-* Ben Schumacher - Engineer
 * Daniel Espino Garcia - Engineer
+* Ben Schumacher - Engineer
+* Jason Frerich - Engineer
 * Dylan Haussermann - QA
-* Aaron Rothschild - Product Manager
-* Justine Geffen - Technical Writer
+* Matt Birtch - UX Designer
 
-### Workflows Team
+#### Full Stack 3 (name TBD)
+* Joram Wilander - Engineering Lead
+* Ashish Bhate - Engineer
+* Anurag Shivarathri - Engineer
+* Kyriakos Ziakoulis - Engineer
+* Jelena Gilliam - QA
+
+#### Web Platform
+* Joram Wilander - Engineering Lead
+* Harrison Healey - Engineer
+* Devin Binnie - Engineer
+* Guillermo Vaya - Engineer
+* Jelena Gilliam - QA
+
+#### Suite Platform
+* Joram Wilander - Engineering Lead
+* Agniva De Sarker - Engineer
+* Ibrahim Acikgoz - Engineer
+
+### Incident Collaboration
 
 * Jesse Hallam - Engineering Lead
 * Christopher Speller - Engineer
@@ -61,6 +73,23 @@ Feature teams are full-stack teams owning collections of features within the Mat
 * Abhijit Singh - UX Designer
 * Justine Geffen - Technical Writer
 
+### Focalboard
+
+* Scott Bishel - Engineering Lead
+* Jesus Espino - Engineer
+* Miguel de la Cruz - Engineer
+* Doug Lauder - Engineer
+* Hossein Ahmadian - Engineer
+* Harshil Sharma - Engineer
+* Ogi Marusic - QA
+* Chen-I Lim - Product Manager
+* Michael Gamble - UX Designer
+
+### Cloud
+
+#### Leadership
+* Jason Blais - Senior Product Manager Lead
+
 ### Cloud Features Team
 
 * Maria Nuñez - Engineering Lead
@@ -69,70 +98,54 @@ Feature teams are full-stack teams owning collections of features within the Mat
 * Pablo Vélez Vidal - Engineer
 * Nick Misasi - Engineer
 * Steve Mudie - QA
-* Adam Clarkson - Product Manager
-* Matt Birtch - UX Designer
+* Anneliese Klein - UX Designer
 * Carrie Warner - Technical Writer
-
-## Platform Teams
-
-Platform Teams are focused on an individual technical specialisation or layer of the Mattermost software stack.
-
-### Mobile Platform Team
-
-* Elias Nahum - Engineering Lead
-* Miguel Alatzar - Engineer
-* Avinash Lingaloo - Engineer
-* Shaz Amjad - Engineer
-* Joseph Baylon - QA SDET
-* Eric Sethna - Product Manager
-* Matt Birtch - UX Designer
-
-### Web and Desktop Platform Team
-
-* Dean Whillier - Engineering Lead
-* Harrison Healey - Engineer
-* Devin Binnie - Engineer
-* Guillermo Vayá - Engineer
-* Nevy Angelova - Engineer
-* Jelena Gilliam - QA
-* Eric Sethna - Product Manager
-* Andrew Brown - UX Designer
-
-### Server Platform Team
-
-* George Goldberg - Engineering Lead
-* Miguel de la Cruz - Engineer
-* Claudio Costa - Engineer
-* Agniva De Sarker - Engineer
-* Doug Lauder - Engineer
-* Ibrahim Acikgoz - Engineer
-* Katie Wiersgalla - Product Manager
 
 ### Cloud Platform Team
 
-* Joram Wilander - Engineering Lead
-* Gabe Jackson - Engineer
+* Gabe Jackson - Engineering Lead
 * Ian Whitlock - Engineer
 * Szymon Gibała - Engineer
 * Adam Clarkson - Product Manager
 
-### QA Platform Team
+## Site Reliability Engineering Team
+
+* Spiros Economakis - Engineering Lead
+* Stylianos Rigas - Engineer
+* Angelos Kyratzakos - Engineer
+* Stavros Foteinopoulos - Engineer
+* Muhammad Shahid - Engineer
+
+## Release/DevOps Team
+
+* Carlos Panato - Engineer, Tech Lead
+* Elisabeth Kulzer - Engineer
+* Amy Blais - Release Manager
+
+### Platform Teams
+
+#### Leadership
+* Zef Hemel - Engineering Lead
+* Jason Blais - Senior Product Manager Lead
+
+#### Mobile Team
+
+* Elias Nahum - Engineering Lead
+* Miguel Alatzar - Engineer
+* Avinash Lingaloo - Engineer
+* Joseph Baylon - QA SDET
+* Eric Sethna - Product Manager
+
+#### QA Team
 
 * Linda Mitchell - QA Lead
 * Saturnino Abril - QA SDET
 * Lindy Isherwood - QA
 
-## Site Reliability Engineering Team
-
-* Joram Wilander - Engineering Lead
-* Stylianos Rigas - Engineer
-* Angelos Kyratzakos - Engineer
-* Stavros Foteinopoulos - Engineer
-
-## Build and Infrastructure Team
-
-* Jason Deland - Engineering Lead
-* Elisabeth Kulzer - Build Engineer
+#### UI Team
+* Dean Whillier - Engineering Lead
+* Nevy Angelova - Engineer
+* Michel Engelen - Engineer
 
 ## Security Team
 
@@ -143,6 +156,6 @@ Platform Teams are focused on an individual technical specialisation or layer of
 * Kennedy Torkura - Cloud Security Engineer
 * Katie Wiersgalla - Product Manager
 
-## Other
-
-* Amy Blais - Release Manager
+## Docs
+* Justine Geffen - Technical Writer
+* Carrie Warner - Technical Writer


### PR DESCRIPTION
Minor adjustments of offboarded staff.

Note:
** The structure of this page is not aligned to teams/verticals. One option is to organize into functional areas. Another is to organize it under a larger umbrella "Engineers", "Product Managers" etc and just list specializations/verticals per person. 
** IMO this should be moved into the Engineering section of the Handbook. Once the content/structure is agreed-on, I can do that. 