### PR TITLE
Change Quickstart link for App integration

### DIFF
--- a/site/content/integrate/getting-started/how-should-i-integrate.md
+++ b/site/content/integrate/getting-started/how-should-i-integrate.md
@@ -30,7 +30,7 @@ To build a richer bot integration, you can make full use of the [Mattermost REST
 
 That's no problem. Our Apps provide a framework with utilities like a key-value store, bot account creation, OAuth permission scopes, and rich UX entry points.
 
-Apps can be written in any language that supports HTTP, and work on our Mobile and Desktop clients. Apps can be hosted anywhere, on a Digital Ocean droplet, AWS EC2, or a server in your data centre. Take a look at our [Quickstart Guide](https://developers.mattermost.com/integrate/apps/quick-start-go/).
+Apps can be written in any language that supports HTTP, and work on our Mobile and Desktop clients. Apps can be hosted anywhere, on a Digital Ocean droplet, AWS EC2, or a server in your data centre. Take a look at our [introduction](https://developers.mattermost.com/integrate/apps/).
 
 ### One of these alone isn't enough
 


### PR DESCRIPTION
#### Summary
The Apps introduction page is a better landing experience for people who are first learning about the Apps framework. This PR changes the link to https://developers.mattermost.com/integrate/apps/

#### Ticket Link
N/a

