### PR TITLE
[MM-35761] Remove references to AWS provisioning and setting AWS server variables

### DIFF
--- a/site/content/integrate/apps/deployment/_index.md
+++ b/site/content/integrate/apps/deployment/_index.md
@@ -3,6 +3,9 @@ title: "Deployment"
 heading: "Deploying Apps"
 description: "TODO"
 weight: 110
+_build:
+ list: false
+ render: false
 ---
 
 Serverless hosting allows for easy app installation from the App Marketplace by a System Admin and uses AWS Lambda serverless technology instead of relying on a physical server. Developers who create apps using a serverless development approach can easily deploy apps securely, efficiently, and at scale in the Mattermost Cloud.

--- a/site/content/integrate/apps/quick-start-go/_index.md
+++ b/site/content/integrate/apps/quick-start-go/_index.md
@@ -14,7 +14,13 @@ This quick start guide explains the basics of writing a Mattermost app. In this 
 
 ## Prerequisites
 
-Before you can start with your app, you first need to set up a local developer environment following the [server](/contribute/server/developer-setup/) and [webapp](/contribute/webapp/developer-setup/) setup guides. You must enable the apps feature flag before starting the Mattermost server by setting the environment variable `MM_FEATUREFLAGS_AppsEnabled` to `true` by e.g. adding `export MM_FEATUREFLAGS_AppsEnabled=true` to your `.bashrc` or using `make run-server MM_FEATUREFLAGS_AppsEnabled=true`. Please also ensure that `Bot Account Creation` and `OAuth 2.0 Service Provider` are enabled in the System Console.
+Before you can start with your app, you first need to set up a local developer environment following the [server](/contribute/server/developer-setup/) and [webapp](/contribute/webapp/developer-setup/) setup guides. You must enable the apps feature flag before starting the Mattermost server by setting the environment variable `MM_FEATUREFLAGS_AppsEnabled` to `true` by e.g. adding `export MM_FEATUREFLAGS_AppsEnabled=true` to your `.bashrc` or using `make run-server MM_FEATUREFLAGS_AppsEnabled=true`.
+
+In the System Console, ensure that the following are set to true:
+
+- `Enable Bot Account Creation`
+- `Enable OAuth 2.0 Service Provider`
+- `Enable Developer Mode`
 
 **Note:** Apps do not work with a production release of Mattermost right now. They can only be run in a development environment. A future release will support production environments.
 

--- a/site/content/integrate/apps/quick-start-go/_index.md
+++ b/site/content/integrate/apps/quick-start-go/_index.md
@@ -16,7 +16,7 @@ This quick start guide explains the basics of writing a Mattermost app. In this 
 
 Before you can start with your app, you first need to set up a local developer environment following the [server](/contribute/server/developer-setup/) and [webapp](/contribute/webapp/developer-setup/) setup guides. You must enable the apps feature flag before starting the Mattermost server by setting the environment variable `MM_FEATUREFLAGS_AppsEnabled` to `true` by e.g. adding `export MM_FEATUREFLAGS_AppsEnabled=true` to your `.bashrc` or using `make run-server MM_FEATUREFLAGS_AppsEnabled=true`.
 
-In the System Console, ensure that the following are set to true:
+In the System Console, ensure that the following are set to **true**:
 
 - `Enable Bot Account Creation`
 - `Enable OAuth 2.0 Service Provider`

--- a/site/content/integrate/apps/quick-start-go/_index.md
+++ b/site/content/integrate/apps/quick-start-go/_index.md
@@ -20,7 +20,7 @@ In the System Console, ensure that the following are set to true:
 
 - `Enable Bot Account Creation`
 - `Enable OAuth 2.0 Service Provider`
-- `Enable Developer Mode`
+- `Enable Developer Mode` (Will require a server restart)
 
 **Note:** Apps do not work with a production release of Mattermost right now. They can only be run in a development environment. A future release will support production environments.
 

--- a/site/content/integrate/apps/quick-start-js/_index.md
+++ b/site/content/integrate/apps/quick-start-js/_index.md
@@ -16,7 +16,13 @@ You can view an example [here](https://github.com/mattermost/mattermost-plugin-a
 
 ## Prerequisites
 
-Before you can start with your app, you first need to set up a local developer environment following the [server](/contribute/server/developer-setup/) and [webapp](/contribute/webapp/developer-setup/) setup guides. You must enable the apps feature flag before starting the Mattermost server by setting the environment variable `MM_FEATUREFLAGS_AppsEnabled` to `true` by e.g. adding `export MM_FEATUREFLAGS_AppsEnabled=true` to your `.bashrc` or using `make run-server MM_FEATUREFLAGS_AppsEnabled=true`. Please also ensure that `Bot Account Creation` and `OAuth 2.0 Service Provider` are enabled in the System Console.
+Before you can start with your app, you first need to set up a local developer environment following the [server](/contribute/server/developer-setup/) and [webapp](/contribute/webapp/developer-setup/) setup guides. You must enable the apps feature flag before starting the Mattermost server by setting the environment variable `MM_FEATUREFLAGS_AppsEnabled` to `true` by e.g. adding `export MM_FEATUREFLAGS_AppsEnabled=true` to your `.bashrc` or using `make run-server MM_FEATUREFLAGS_AppsEnabled=true`.
+
+In the System Console, ensure that the following are set to true:
+
+- `Enable Bot Account Creation`
+- `Enable OAuth 2.0 Service Provider`
+- `Enable Developer Mode`
 
 **Note:** Apps do not work with a production release of Mattermost right now. They can only be run in a development environment. A future release will support production environments.
 

--- a/site/content/integrate/apps/quick-start-js/_index.md
+++ b/site/content/integrate/apps/quick-start-js/_index.md
@@ -18,7 +18,7 @@ You can view an example [here](https://github.com/mattermost/mattermost-plugin-a
 
 Before you can start with your app, you first need to set up a local developer environment following the [server](/contribute/server/developer-setup/) and [webapp](/contribute/webapp/developer-setup/) setup guides. You must enable the apps feature flag before starting the Mattermost server by setting the environment variable `MM_FEATUREFLAGS_AppsEnabled` to `true` by e.g. adding `export MM_FEATUREFLAGS_AppsEnabled=true` to your `.bashrc` or using `make run-server MM_FEATUREFLAGS_AppsEnabled=true`.
 
-In the System Console, ensure that the following are set to true:
+In the System Console, ensure that the following are set to **true**:
 
 - `Enable Bot Account Creation`
 - `Enable OAuth 2.0 Service Provider`

--- a/site/content/integrate/apps/quick-start-js/_index.md
+++ b/site/content/integrate/apps/quick-start-js/_index.md
@@ -22,7 +22,7 @@ In the System Console, ensure that the following are set to true:
 
 - `Enable Bot Account Creation`
 - `Enable OAuth 2.0 Service Provider`
-- `Enable Developer Mode`
+- `Enable Developer Mode` (Will require a server restart)
 
 **Note:** Apps do not work with a production release of Mattermost right now. They can only be run in a development environment. A future release will support production environments.
 


### PR DESCRIPTION
#### Summary
This PR removes the deployment sidebar link and adds the developer mode setting requiremenet.

![image](https://user-images.githubusercontent.com/7575921/118300817-f5b8d000-b4a7-11eb-97d1-41d5a4b50cc0.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35761