### PR TITLE
Fix App quick start links to point to examples/go/hello-world instead of helloworld

### DIFF
--- a/site/content/integrate/apps/bindings/_index.md
+++ b/site/content/integrate/apps/bindings/_index.md
@@ -16,7 +16,7 @@ Bindings ([godoc](https://pkg.go.dev/github.com/mattermost/mattermost-plugin-app
 
 **Note:** When an OAuth2 process is completed, the client's bindings are automatically refreshed. For any other case where bindings need to be refreshed, the user will need to switch channels (which always fetches new bindings), or refresh the page.
 
-One example bindings response is the one from the [Hello World!](https://github.com/mattermost/mattermost-plugin-apps/blob/master/examples/go/helloworld/bindings.json) app. 
+One example bindings response is the one from the [Hello World!](https://github.com/mattermost/mattermost-plugin-apps/blob/master/examples/go/hello-world/bindings.json) app.
 
 The expected response should include the following:
 

--- a/site/content/integrate/apps/interactivity/_index.md
+++ b/site/content/integrate/apps/interactivity/_index.md
@@ -7,7 +7,7 @@ weight: 50
 
 ### Modal Forms
 
-Modal Forms ([godoc](https://pkg.go.dev/github.com/mattermost/mattermost-plugin-apps/apps#Form)) open as a modal on the user interface as a result of a Form call response. One example is the `send` form in the [Hello World!](https://github.com/mattermost/mattermost-plugin-apps/blob/master/examples/go/helloworld/send_form.json) app. 
+Modal Forms ([godoc](https://pkg.go.dev/github.com/mattermost/mattermost-plugin-apps/apps#Form)) open as a modal on the user interface as a result of a Form call response. One example is the `send` form in the [Hello World!](https://github.com/mattermost/mattermost-plugin-apps/blob/master/examples/go/hello-world/send_form.json) app.
 
 They are defined by:
 

--- a/site/content/integrate/apps/quick-start-go/_index.md
+++ b/site/content/integrate/apps/quick-start-go/_index.md
@@ -167,7 +167,7 @@ Apps may include static assets. One example that was already used above is the `
 Download an example icon using:
 
 ```bash
-curl https://github.com/mattermost/mattermost-plugin-apps/raw/master/examples/go/helloworld/icon.png -o icon.png
+curl https://github.com/mattermost/mattermost-plugin-apps/raw/master/examples/go/hello-world/icon.png -o icon.png
 ```
 
 ### Serving the data

--- a/site/content/integrate/apps/quick-start-js/_index.md
+++ b/site/content/integrate/apps/quick-start-js/_index.md
@@ -188,7 +188,7 @@ Apps may include static assets. One example that was already used above is the `
 Download an example icon using:
 
 ```bash
-curl https://github.com/mattermost/mattermost-plugin-apps/raw/master/examples/go/helloworld/icon.png -o icon.png
+curl https://github.com/mattermost/mattermost-plugin-apps/raw/master/examples/go/hello-world/icon.png -o icon.png
 ```
 
 And then add another handler:

--- a/site/content/integrate/apps/quick-start-js/_index.md
+++ b/site/content/integrate/apps/quick-start-js/_index.md
@@ -189,7 +189,7 @@ Apps may include static assets. One example that was already used above is the `
 Download an example icon using:
 
 ```bash
-curl https://github.com/mattermost/mattermost-plugin-apps/raw/master/examples/go/hello-world/icon.png -o icon.png
+curl https://github.com/mattermost/mattermost-plugin-apps/raw/master/examples/js/hello-world/icon.png -o icon.png
 ```
 
 And then add another handler:

--- a/site/content/integrate/apps/quick-start-js/_index.md
+++ b/site/content/integrate/apps/quick-start-js/_index.md
@@ -57,6 +57,7 @@ Then create a file called `app.js` containing a simple HTTP server:
 
 ```js
 const express = require('express');
+const fetch = require('node-fetch'); // for later use
 
 const app = express();
 app.use(express.json());
@@ -203,8 +204,6 @@ app.get('/static/icon.png', (req, res) => {
 Finally, add the application logic that gets executed when either the slash command is run or the modal submitted:
 
 ```js
-app.use(express.json());
-
 app.post('/send/submit', async (req, res) => {
     const call = req.body;
 


### PR DESCRIPTION
#### Summary

The icon link in https://developers.mattermost.com/integrate/apps/quick-start-js is not working because it's pointing to https://github.com/mattermost/mattermost-plugin-apps/raw/master/examples/go/helloworld/icon.png instead of https://github.com/mattermost/mattermost-plugin-apps/raw/master/examples/go/hello-world/icon.png.