### PR TITLE
Remove reference to Extend section

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -91,7 +91,6 @@ pygmentsStyle = "manni"
     [[params.navigation.drafts]]
       Contribute = false
       Integrate = false
-      Extend = false
       Blog = false
       Internal = false
       'Admin Docs' = false

--- a/site/config.toml
+++ b/site/config.toml
@@ -73,7 +73,7 @@ pygmentsStyle = "manni"
 
     [[menu.postpend]]
       url = "/integrate/getting-started/"
-      name = "Integrate"
+      name = "Integrate & Extend"
       weight = 2
 
     [[menu.postpend]]
@@ -90,7 +90,7 @@ pygmentsStyle = "manni"
     # Workaround to add draft status to menu items
     [[params.navigation.drafts]]
       Contribute = false
-      Integrate = false
+      "Integrate & Extend" = false
       Blog = false
       Internal = false
       'Admin Docs' = false

--- a/site/config.toml
+++ b/site/config.toml
@@ -73,7 +73,7 @@ pygmentsStyle = "manni"
 
     [[menu.postpend]]
       url = "/integrate/getting-started/"
-      name = "Integrate & Extend"
+      name = "Integrate"
       weight = 2
 
     [[menu.postpend]]


### PR DESCRIPTION


#### Summary
I missed this reference to the deprecated Extend section in my first pass.

#### Ticket Link
None

