### PR TITLE
Be more explicit about bindings fetching

### DIFF
--- a/site/content/integrate/apps/bindings/_index.md
+++ b/site/content/integrate/apps/bindings/_index.md
@@ -14,7 +14,7 @@ Bindings ([godoc](https://pkg.go.dev/github.com/mattermost/mattermost-plugin-app
 - The ID of the channel the user is currently focused on
 - The ID of the post the user is currently focused on (if applicable)
 
-**Note:** When an OAuth2 process is completed, the client's bindings are automatically refreshed. For any other case where bindings need to be refreshed, the user will need to switch channels (which always fetches new bindings), or refresh the page.
+**Note:** Bindings are fetched (and refreshed) on every channel switch. When the user gets to a different context (like opening a thread, or a post in a search view) new bindings may be fetched to provide the correct bindings for the thread / post context. Bindings are also fetched when an OAuth2 process is completed and when the application gets installed.
 
 One example bindings response is the one from the [Hello World!](https://github.com/mattermost/mattermost-plugin-apps/blob/master/examples/go/hello-world/bindings.json) app.
 

--- a/site/content/integrate/apps/bindings/_index.md
+++ b/site/content/integrate/apps/bindings/_index.md
@@ -14,7 +14,7 @@ Bindings ([godoc](https://pkg.go.dev/github.com/mattermost/mattermost-plugin-app
 - The ID of the channel the user is currently focused on
 - The ID of the post the user is currently focused on (if applicable)
 
-**Note:** Bindings are fetched (and refreshed) on every channel switch. When the user gets to a different context (like opening a thread, or a post in a search view) new bindings may be fetched to provide the correct bindings for the thread / post context. Bindings are also fetched when an OAuth2 process is completed and when the application gets installed.
+**Note:** Bindings are fetched (and refreshed) on every channel switch. When the user moves to a different context (like opening a thread, or a post in a search view) new bindings may be fetched to provide the correct bindings for the thread/post context. Bindings are also fetched when an OAuth2 process is completed and when the application gets installed.
 
 One example bindings response is the one from the [Hello World!](https://github.com/mattermost/mattermost-plugin-apps/blob/master/examples/go/hello-world/bindings.json) app.
 


### PR DESCRIPTION
#### Summary
Be a bit more explicit on when the bindings will be fetched.

The reasoning behind this change is to make clear that threads and posts will always have the bindings according to their context. 

#### Related PRs
https://github.com/mattermost/mattermost-mobile/pull/5563
https://github.com/mattermost/mattermost-webapp/pull/8439
