### PR TITLE
Added info about Open forms from other bindings, and updated bindings requirements.

### DIFF
--- a/site/content/integrate/apps/bindings/_index.md
+++ b/site/content/integrate/apps/bindings/_index.md
@@ -43,7 +43,7 @@ Bindings are organized by top level locations. Top level bindings just need to d
 | `call`     | Call   | (Optional) Call to perform. You must provide a call if there is no form, or the form itself does not have a call. |
 | `form`     | Form   | (Optional) Modal form to open. You must provide a Form with a Call if there is no Call defined in the Binding.    |
 
-The call for these bindings will include in the context the user ID, the post ID, the root post ID if any, the channel ID and the team ID.
+The call for these bindings will include in the context the user ID, the post ID, the root post ID if any, the channel ID, and the team ID.
 
 ### `/channel_header` bindings
 

--- a/site/content/integrate/apps/bindings/_index.md
+++ b/site/content/integrate/apps/bindings/_index.md
@@ -54,7 +54,7 @@ The call for these bindings will include in the context the user ID, the post ID
 | `label`    | string | (Optional) Text to show in the item on mobile and webapp collapsed view. Defaults to location. Must be unique in its level. |
 | `hint`     | string | (Optional / Webapp Required) Text to show in tooltip.                                                                       |
 | `call`     | Call   | (Optional) Call to perform. You must provide a call if there is no form, or the form itself does not have a call.           |
-| `form`     | Form   | (Optional) Modal form to open. You must provide a Form with a Call if there is no Call defined in the Binding.              |
+| `form`     | Form   | (Optional) Modal form to open. You must provide a form with a call if there is no call defined in the binding.              |
 
 The context of the call for these bindings will include the user ID, the channel ID, and the team ID.
 

--- a/site/content/integrate/apps/bindings/_index.md
+++ b/site/content/integrate/apps/bindings/_index.md
@@ -85,7 +85,7 @@ A leaf command must include:
 | `call`        | Call   | (Optional) Call to perform when executing the command. You must provide a call if there is no form, or the form itself does not have a call. |                                                                                                    |
 | `form`        | Form   | (Optional) Form representing the parameters the command can receive. If no form is provided, a form call will be made to the specified call. |
 
-The context of the call for these bindings will include the user ID, the post ID, the root post ID (if any), the channel ID and the team ID. It will also include the raw command.
+The context of the call for these bindings will include the user ID, the post ID, the root post ID (if any), the channel ID, and the team ID. It will also include the raw command.
 
 ## Example data flow
 

--- a/site/content/integrate/apps/bindings/_index.md
+++ b/site/content/integrate/apps/bindings/_index.md
@@ -37,9 +37,9 @@ Bindings are organized by top level locations. Top level bindings just need to d
 
 | Name       | Type   | Description                                                                                                       |
 | :--------- | :----- | :---------------------------------------------------------------------------------------------------------------- |
-| `location` | string | Name of this location. The whole path of locations will be added in the context.                                  |
+| `location` | string | Name of this location. The whole path of locations will be added in the context. Must be unique in its level.     |
 | `icon`     | string | (Optional) Either a fully-qualified URL, or a path for an app's static asset.                                     |
-| `label`    | string | (Optional) Text to show in the item. Defaults to location.                                                        |
+| `label`    | string | (Optional) Text to show in the item. Defaults to location. Must be unique in its level.                           |
 | `call`     | Call   | (Optional) Call to perform. You must provide a Call if there is no Form, or the Form itself does not have a Call. |
 | `form`     | Form   | (Optional) Modal form to open. You must provide a Form with a Call if there is no Call defined in the Binding.    |
 
@@ -47,14 +47,14 @@ The call for these bindings will include in the context the user ID, the post ID
 
 ### `/channel_header` bindings
 
-| Name       | Type   | Description                                                                                                       |
-| :--------- | :----- | :---------------------------------------------------------------------------------------------------------------- |
-| `location` | string | Name of this location. The whole path of locations will be added in the context.                                  |
-| `icon`     | string | (Optional / Webapp Required) Either a fully-qualified URL, or a path for an app's static asset.                   |
-| `label`    | string | (Optional) Text to show in the item on mobile and webapp collapsed view. Defaults to location.                    |
-| `hint`     | string | (Optional / Webapp Required) Text to show in tooltip.                                                             |
-| `call`     | Call   | (Optional) Call to perform. You must provide a Call if there is no Form, or the Form itself does not have a Call. |
-| `form`     | Form   | (Optional) Modal form to open. You must provide a Form with a Call if there is no Call defined in the Binding.    |
+| Name       | Type   | Description                                                                                                                 |
+| :--------- | :----- | :-------------------------------------------------------------------------------------------------------------------------- |
+| `location` | string | Name of this location. The whole path of locations will be added in the context. Must be unique in its level.               |
+| `icon`     | string | (Optional / Webapp Required) Either a fully-qualified URL, or a path for an app's static asset.                             |
+| `label`    | string | (Optional) Text to show in the item on mobile and webapp collapsed view. Defaults to location. Must be unique in its level. |
+| `hint`     | string | (Optional / Webapp Required) Text to show in tooltip.                                                                       |
+| `call`     | Call   | (Optional) Call to perform. You must provide a Call if there is no Form, or the Form itself does not have a Call.           |
+| `form`     | Form   | (Optional) Modal form to open. You must provide a Form with a Call if there is no Call defined in the Binding.              |
 
 The context of the call for these bindings will include the user ID, the channel ID, and the team ID.
 
@@ -64,22 +64,22 @@ For commands we can distinguish between leaf commands (executable subcommand) an
 
 A partial command must include:
 
-| Name          | Type     | Description                                                                                  |
-| :------------ | :------- | :------------------------------------------------------------------------------------------- |
-| `location`    | string   | Name of this location. The whole path of locations will be added in the context.             |
-| `label`       | string   | The label to use to define the command. Cannot include spaces or tabs. Defaults to location. |
-| `hint`        | string   | (Optional) Hint line on command autocomplete.                                                |
-| `description` | string   | (Optional) Description line on command autocomplete.                                         |
-| `bindings`    | Bindings | List of subcommands.                                                                         |
-| `call`        | Call     | (Optional) Call to be inherited by all its subcommands.                                      |
-| `form`        | Form     | (Optional) Form to be inherited by all its subcommands.                                      |
+| Name          | Type     | Description                                                                                                               |
+| :------------ | :------- | :------------------------------------------------------------------------------------------------------------------------ |
+| `location`    | string   | Name of this location. The whole path of locations will be added in the context. Must be unique in its level.             |
+| `label`       | string   | The label to use to define the command. Cannot include spaces or tabs. Defaults to location. Must be unique in its level. |
+| `hint`        | string   | (Optional) Hint line on command autocomplete.                                                                             |
+| `description` | string   | (Optional) Description line on command autocomplete.                                                                      |
+| `bindings`    | Bindings | List of subcommands.                                                                                                      |
+| `call`        | Call     | (Optional) Call to be inherited by all its subcommands.                                                                   |
+| `form`        | Form     | (Optional) Form to be inherited by all its subcommands.                                                                   |
 
 A leaf command must include:
 
 | Name          | Type   | Description                                                                                                                                  |
 | :------------ | :----- | :------------------------------------------------------------------------------------------------------------------------------------------- |
-| `location`    | string | Name of this location. The whole path of locations will be added in the context.                                                               |
-| `label`       | string | The label to use to define the command. Cannot include spaces or tabs. Defaults to location.                                                   |
+| `location`    | string | Name of this location. The whole path of locations will be added in the context. Must be unique in its level.                                   |
+| `label`       | string | The label to use to define the command. Cannot include spaces or tabs. Defaults to location. Must be unique in its level.                       |
 | `hint`        | string | (Optional) Hint line on command autocomplete.                                                                                                   |
 | `description` | string | (Optional) Description line on command autocomplete.                                                                                           |
 | `call`        | Call   | (Optional) Call to perform when executing the command. You must provide a Call if there is no Form, or the Form itself does not have a Call. |                                                                                                    |

--- a/site/content/integrate/apps/bindings/_index.md
+++ b/site/content/integrate/apps/bindings/_index.md
@@ -52,7 +52,7 @@ The call for these bindings will include in the context the user ID, the post ID
 | `location` | string | Name of this location. The whole path of locations will be added in the context. Must be unique in its level.               |
 | `icon`     | string | (Optional/Web App required) Either a fully-qualified URL, or a path for an app's static asset.                             |
 | `label`    | string | (Optional) Text to show in the item on mobile and webapp collapsed view. Defaults to location. Must be unique in its level. |
-| `hint`     | string | (Optional / Webapp Required) Text to show in tooltip.                                                                       |
+| `hint`     | string | (Optional/Web App required) Text to show in tooltip.                                                                       |
 | `call`     | Call   | (Optional) Call to perform. You must provide a call if there is no form, or the form itself does not have a call.           |
 | `form`     | Form   | (Optional) Modal form to open. You must provide a form with a call if there is no call defined in the binding.              |
 

--- a/site/content/integrate/apps/bindings/_index.md
+++ b/site/content/integrate/apps/bindings/_index.md
@@ -40,7 +40,7 @@ Bindings are organized by top level locations. Top level bindings just need to d
 | `location` | string | Name of this location. The whole path of locations will be added in the context. Must be unique in its level.     |
 | `icon`     | string | (Optional) Either a fully-qualified URL, or a path for an app's static asset.                                     |
 | `label`    | string | (Optional) Text to show in the item. Defaults to location. Must be unique in its level.                           |
-| `call`     | Call   | (Optional) Call to perform. You must provide a Call if there is no Form, or the Form itself does not have a Call. |
+| `call`     | Call   | (Optional) Call to perform. You must provide a call if there is no form, or the form itself does not have a call. |
 | `form`     | Form   | (Optional) Modal form to open. You must provide a Form with a Call if there is no Call defined in the Binding.    |
 
 The call for these bindings will include in the context the user ID, the post ID, the root post ID if any, the channel ID and the team ID.

--- a/site/content/integrate/apps/bindings/_index.md
+++ b/site/content/integrate/apps/bindings/_index.md
@@ -50,7 +50,7 @@ The call for these bindings will include in the context the user ID, the post ID
 | Name       | Type   | Description                                                                                                                 |
 | :--------- | :----- | :-------------------------------------------------------------------------------------------------------------------------- |
 | `location` | string | Name of this location. The whole path of locations will be added in the context. Must be unique in its level.               |
-| `icon`     | string | (Optional / Webapp Required) Either a fully-qualified URL, or a path for an app's static asset.                             |
+| `icon`     | string | (Optional/Web App required) Either a fully-qualified URL, or a path for an app's static asset.                             |
 | `label`    | string | (Optional) Text to show in the item on mobile and webapp collapsed view. Defaults to location. Must be unique in its level. |
 | `hint`     | string | (Optional / Webapp Required) Text to show in tooltip.                                                                       |
 | `call`     | Call   | (Optional) Call to perform. You must provide a call if there is no form, or the form itself does not have a call.           |

--- a/site/content/integrate/apps/bindings/_index.md
+++ b/site/content/integrate/apps/bindings/_index.md
@@ -53,7 +53,7 @@ The call for these bindings will include in the context the user ID, the post ID
 | `icon`     | string | (Optional / Webapp Required) Either a fully-qualified URL, or a path for an app's static asset.                             |
 | `label`    | string | (Optional) Text to show in the item on mobile and webapp collapsed view. Defaults to location. Must be unique in its level. |
 | `hint`     | string | (Optional / Webapp Required) Text to show in tooltip.                                                                       |
-| `call`     | Call   | (Optional) Call to perform. You must provide a Call if there is no Form, or the Form itself does not have a Call.           |
+| `call`     | Call   | (Optional) Call to perform. You must provide a call if there is no form, or the form itself does not have a call.           |
 | `form`     | Form   | (Optional) Modal form to open. You must provide a Form with a Call if there is no Call defined in the Binding.              |
 
 The context of the call for these bindings will include the user ID, the channel ID, and the team ID.

--- a/site/content/integrate/apps/bindings/_index.md
+++ b/site/content/integrate/apps/bindings/_index.md
@@ -82,7 +82,7 @@ A leaf command must include:
 | `label`       | string | The label to use to define the command. Cannot include spaces or tabs. Defaults to location. Must be unique in its level.                       |
 | `hint`        | string | (Optional) Hint line on command autocomplete.                                                                                                   |
 | `description` | string | (Optional) Description line on command autocomplete.                                                                                           |
-| `call`        | Call   | (Optional) Call to perform when executing the command. You must provide a Call if there is no Form, or the Form itself does not have a Call. |                                                                                                    |
+| `call`        | Call   | (Optional) Call to perform when executing the command. You must provide a call if there is no form, or the form itself does not have a call. |                                                                                                    |
 | `form`        | Form   | (Optional) Form representing the parameters the command can receive. If no form is provided, a form call will be made to the specified call. |
 
 The context of the call for these bindings will include the user ID, the post ID, the root post ID (if any), the channel ID and the team ID. It will also include the raw command.

--- a/site/content/integrate/apps/bindings/_index.md
+++ b/site/content/integrate/apps/bindings/_index.md
@@ -41,7 +41,7 @@ Bindings are organized by top level locations. Top level bindings just need to d
 | `icon`     | string | (Optional) Either a fully-qualified URL, or a path for an app's static asset.                                     |
 | `label`    | string | (Optional) Text to show in the item. Defaults to location. Must be unique in its level.                           |
 | `call`     | Call   | (Optional) Call to perform. You must provide a call if there is no form, or the form itself does not have a call. |
-| `form`     | Form   | (Optional) Modal form to open. You must provide a Form with a Call if there is no Call defined in the Binding.    |
+| `form`     | Form   | (Optional) Modal form to open. You must provide a form with a call if there is no call defined in the binding.    |
 
 The call for these bindings will include in the context the user ID, the post ID, the root post ID if any, the channel ID, and the team ID.
 

--- a/site/content/integrate/apps/bindings/_index.md
+++ b/site/content/integrate/apps/bindings/_index.md
@@ -35,24 +35,26 @@ Bindings are organized by top level locations. Top level bindings just need to d
 
 ### `/post_menu` bindings
 
-| Name       | Type   | Description                                                                     |
-| :--------- | :----- | :------------------------------------------------------------------------------ |
-| `location` | string | Name of this location. The whole path of locations will be added in the context |
-| `icon`     | string | (Optional) Either a fully-qualified URL, or a path for an app's static asset.   |
-| `label`    | string | Text to show in the item.                                                       |
-| `call`     | Call   | Call to perform.                                                                |
+| Name       | Type   | Description                                                                                                       |
+| :--------- | :----- | :---------------------------------------------------------------------------------------------------------------- |
+| `location` | string | Name of this location. The whole path of locations will be added in the context.                                  |
+| `icon`     | string | (Optional) Either a fully-qualified URL, or a path for an app's static asset.                                     |
+| `label`    | string | (Optional) Text to show in the item. Defaults to location.                                                        |
+| `call`     | Call   | (Optional) Call to perform. You must provide a Call if there is no Form, or the Form itself does not have a Call. |
+| `form`     | Form   | (Optional) Modal form to open. You must provide a Form with a Call if there is no Call defined in the Binding.    |
 
 The call for these bindings will include in the context the user ID, the post ID, the root post ID if any, the channel ID and the team ID.
 
 ### `/channel_header` bindings
 
-| Name       | Type   | Description                                                                      |
-| :--------- | :----- | :------------------------------------------------------------------------------- |
-| `location` | string | Name of this location. The whole path of locations will be added in the context. |
-| `icon`     | string | (Optional) Either a fully-qualified URL, or a path for an app's static asset.    |
-| `label`    | string | Text to show in the item on mobile and webapp collapsed view.                    |
-| `hint`     | string | Text to show in tooltip.                                                         |
-| `call`     | Call   | Call to perform.                                                                 |
+| Name       | Type   | Description                                                                                                       |
+| :--------- | :----- | :---------------------------------------------------------------------------------------------------------------- |
+| `location` | string | Name of this location. The whole path of locations will be added in the context.                                  |
+| `icon`     | string | (Optional / Webapp Required) Either a fully-qualified URL, or a path for an app's static asset.                   |
+| `label`    | string | (Optional) Text to show in the item on mobile and webapp collapsed view. Defaults to location.                    |
+| `hint`     | string | (Optional / Webapp Required) Text to show in tooltip.                                                             |
+| `call`     | Call   | (Optional) Call to perform. You must provide a Call if there is no Form, or the Form itself does not have a Call. |
+| `form`     | Form   | (Optional) Modal form to open. You must provide a Form with a Call if there is no Call defined in the Binding.    |
 
 The context of the call for these bindings will include the user ID, the channel ID, and the team ID.
 
@@ -62,21 +64,25 @@ For commands we can distinguish between leaf commands (executable subcommand) an
 
 A partial command must include:
 
-| Name          | Type     | Description                                          |
-| :------------ | :------- | :--------------------------------------------------- |
-| `location`    | string   | The label to use to define the command.              |
-| `hint`        | string   | (Optional) Hint line on command autocomplete.        |
-| `description` | string   | (Optional) Description line on command autocomplete. |
-| `bindings`    | Bindings | List of subcommands.                                 |
+| Name          | Type     | Description                                                                                  |
+| :------------ | :------- | :------------------------------------------------------------------------------------------- |
+| `location`    | string   | Name of this location. The whole path of locations will be added in the context.             |
+| `label`       | string   | The label to use to define the command. Cannot include spaces or tabs. Defaults to location. |
+| `hint`        | string   | (Optional) Hint line on command autocomplete.                                                |
+| `description` | string   | (Optional) Description line on command autocomplete.                                         |
+| `bindings`    | Bindings | List of subcommands.                                                                         |
+| `call`        | Call     | (Optional) Call to be inherited by all its subcommands.                                      |
+| `form`        | Form     | (Optional) Form to be inherited by all its subcommands.                                      |
 
 A leaf command must include:
 
 | Name          | Type   | Description                                                                                                                                  |
 | :------------ | :----- | :------------------------------------------------------------------------------------------------------------------------------------------- |
-| `location`    | string | The label to use to define the command.                                                                                                      |
-| `hint`        | string | (Optional) Hint line on command autocomplete.                                                                                                |
-| `description` | string | (Optional) Description line on command autocomplete.                                                                                         |
-| `call`        | Call   | Call to perform when executing the command.                                                                                                  |
+| `location`    | string | Name of this location. The whole path of locations will be added in the context.                                                               |
+| `label`       | string | The label to use to define the command. Cannot include spaces or tabs. Defaults to location.                                                   |
+| `hint`        | string | (Optional) Hint line on command autocomplete.                                                                                                   |
+| `description` | string | (Optional) Description line on command autocomplete.                                                                                           |
+| `call`        | Call   | (Optional) Call to perform when executing the command. You must provide a Call if there is no Form, or the Form itself does not have a Call. |                                                                                                    |
 | `form`        | Form   | (Optional) Form representing the parameters the command can receive. If no form is provided, a form call will be made to the specified call. |
 
 The context of the call for these bindings will include the user ID, the post ID, the root post ID (if any), the channel ID and the team ID. It will also include the raw command.


### PR DESCRIPTION
#### Summary
I piggybacked two different changes on this PR:
- Open forms from any location. Now, if a binding for post_menu or channel_header has a form, it will open directly a modal form.
- Binding filtering. We added several filters to bindings, to make sure they are well formed. Updated the documentation to take those in consideration.

#### Related PRs
Open form in any location
https://github.com/mattermost/mattermost-mobile/pull/5665
https://github.com/mattermost/mattermost-webapp/pull/8784
Filtering:
https://github.com/mattermost/mattermost-webapp/pull/8782
https://github.com/mattermost/mattermost-mobile/pull/5655