### PR TITLE
Fix bot token expiry docs links

### DIFF
--- a/site/content/integrate/admin-guide/admin-bot-accounts/_index.md
+++ b/site/content/integrate/admin-guide/admin-bot-accounts/_index.md
@@ -145,7 +145,7 @@ Replace the following parameters:
 No, but you can automate your integration to cycle its token through the REST API:
 1. Use [CreateUserAccessToken](https://api.mattermost.com/#operation/CreateUserAccessToken) to generate a new token.
 2. Update the services that leverage the token with the new `token` value from step 1
-3. [RevokeUserAccessToken](https://api.mattermost.com/#operation/RevokeUserAccessToken) to revoke the old token based on the `token_id`
+3. Use RevokeUserAccessToken](https://api.mattermost.com/#operation/RevokeUserAccessToken) to revoke the old token based on the `token_id`.
 
 For more information about access tokens, see [the personal access tokens documentation](../admin-personal-access-token).
 

--- a/site/content/integrate/admin-guide/admin-bot-accounts/_index.md
+++ b/site/content/integrate/admin-guide/admin-bot-accounts/_index.md
@@ -143,7 +143,7 @@ Replace the following parameters:
 ### Do bot access tokens expire?
 
 No, but you can automate your integration to cycle its token through the REST API:
-1. [CreateUserAccessToken](https://api.mattermost.com/#operation/CreateUserAccessToken) to generate a new token
+1. Use [CreateUserAccessToken](https://api.mattermost.com/#operation/CreateUserAccessToken) to generate a new token.
 2. Update the services that leverage the token with the new `token` value from step 1
 3. [RevokeUserAccessToken](https://api.mattermost.com/#operation/RevokeUserAccessToken) to revoke the old token based on the `token_id`
 

--- a/site/content/integrate/admin-guide/admin-bot-accounts/_index.md
+++ b/site/content/integrate/admin-guide/admin-bot-accounts/_index.md
@@ -142,7 +142,10 @@ Replace the following parameters:
 
 ### Do bot access tokens expire?
 
-No, but you can automate your integration to cycle its token [through the REST API](https://api.mattermost.com/#tag/users%2Fpaths%2F~1users~1%7Buser_id%7D~1tokens%2Fpost).
+No, but you can automate your integration to cycle its token through the REST API.  Use:
+1. [CreateUserAccessToken](https://api.mattermost.com/#operation/CreateUserAccessToken) to generate a new token
+2. Update the services that leverage the token with the new `token` value from step 1
+3. [RevokeUserAccessToken](https://api.mattermost.com/#operation/RevokeUserAccessToken) to revoke the old token based on the `token_id`
 
 For more information about access tokens, see [the personal access tokens documentation](../admin-personal-access-token).
 

--- a/site/content/integrate/admin-guide/admin-bot-accounts/_index.md
+++ b/site/content/integrate/admin-guide/admin-bot-accounts/_index.md
@@ -144,7 +144,7 @@ Replace the following parameters:
 
 No, but you can automate your integration to cycle its token through the REST API:
 1. Use [CreateUserAccessToken](https://api.mattermost.com/#operation/CreateUserAccessToken) to generate a new token.
-2. Update the services that leverage the token with the new `token` value from step 1
+2. Update the services that leverage the token with the new `token` value from step 1.
 3. Use RevokeUserAccessToken](https://api.mattermost.com/#operation/RevokeUserAccessToken) to revoke the old token based on the `token_id`.
 
 For more information about access tokens, see [the personal access tokens documentation](../admin-personal-access-token).

--- a/site/content/integrate/admin-guide/admin-bot-accounts/_index.md
+++ b/site/content/integrate/admin-guide/admin-bot-accounts/_index.md
@@ -142,7 +142,7 @@ Replace the following parameters:
 
 ### Do bot access tokens expire?
 
-No, but you can automate your integration to cycle its token through the REST API.  Use:
+No, but you can automate your integration to cycle its token through the REST API:
 1. [CreateUserAccessToken](https://api.mattermost.com/#operation/CreateUserAccessToken) to generate a new token
 2. Update the services that leverage the token with the new `token` value from step 1
 3. [RevokeUserAccessToken](https://api.mattermost.com/#operation/RevokeUserAccessToken) to revoke the old token based on the `token_id`

--- a/site/content/integrate/admin-guide/admin-bot-accounts/_index.md
+++ b/site/content/integrate/admin-guide/admin-bot-accounts/_index.md
@@ -143,9 +143,10 @@ Replace the following parameters:
 ### Do bot access tokens expire?
 
 No, but you can automate your integration to cycle its token through the REST API:
-1. Use [CreateUserAccessToken](https://api.mattermost.com/#operation/CreateUserAccessToken) to generate a new token.
-2. Update the services that leverage the token with the new `token` value from step 1.
-3. Use RevokeUserAccessToken](https://api.mattermost.com/#operation/RevokeUserAccessToken) to revoke the old token based on the `token_id`.
+1. Use [GetUserAccessTokensForUser](https://api.mattermost.com/#operation/GetUserAccessTokensForUser) to list the existing tokens for the `bot` user.
+2. Use [CreateUserAccessToken](https://api.mattermost.com/#operation/CreateUserAccessToken) to generate a new token.
+3. Update the services that leverage the token with the new `token` value from step 1.
+4. Use [RevokeUserAccessToken](https://api.mattermost.com/#operation/RevokeUserAccessToken) to revoke the old token based on the `token_id`.
 
 For more information about access tokens, see [the personal access tokens documentation](../admin-personal-access-token).
 


### PR DESCRIPTION
Fixed the API link we use, and added some additional bullets on how the flow for refreshing a bot token would work.

