### PR TITLE
Fix go packages guide bad link

### DIFF
--- a/site/content/contribute/server/style-guide.md
+++ b/site/content/contribute/server/style-guide.md
@@ -37,7 +37,7 @@ Putting everything under `internal` has the advantage that you're free to change
 
 Following are some of the anti-patterns to keep in mind:
 
-- Don't use the `pkg` pattern. This is a common standard used by many projects. But it goes against the Go philosophy of naming packages that signify what they contain. From https://blog.golang.org/package-names:
+- Don't use the `pkg` pattern. This is a common standard used by many projects. But it goes against the Go philosophy of naming packages that signify what they contain. From https://blog.golang.org/package-names :
 
 >  A package's name provides context for its contents, making it easier for clients to understand what the package is for and how to use it.
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

This PR fixes the incorrect link formatting for golang package guide

#### Ticket Link
None
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

