### PR TITLE
Add info to customize Makefile and docker-compose

### DIFF
--- a/site/content/contribute/server/developer-setup.md
+++ b/site/content/contribute/server/developer-setup.md
@@ -54,4 +54,4 @@ You can customize variables of the Makefile by creating a `config.override.mk` f
 
 #### Docker-compose
 
-If you create a `docker-compose.override.yaml` file at the root of the project, it will be automatically loaded by all the Makefile tasks using docker-compose, allowing you to define your own services or change the configuration of the one mattermost provides.
+If you create a `docker-compose.override.yaml` file at the root of the project, it will be automatically loaded by all the `Makefile` tasks using `docker-compose`, allowing you to define your own services or change the configuration of the ones mattermost provides.

--- a/site/content/contribute/server/developer-setup.md
+++ b/site/content/contribute/server/developer-setup.md
@@ -45,13 +45,3 @@ For minimum software requirements, see the following table:
 <div id="centos" class="tabcontent">
     {{% content "contribute/server/developer-setup/centos.md" %}}
 </div>
-
-### Customize your workflow
-
-#### Makefile
-
-You can customize variables of the Makefile by creating a `config.override.mk` file or setting environment variables. To get started, you can copy the `config.mk` file to `config.override.mk` and change the values in your newly copied file.
-
-#### Docker-compose
-
-If you create a `docker-compose.override.yaml` file at the root of the project, it will be automatically loaded by all the `Makefile` tasks using `docker-compose`, allowing you to define your own services or change the configuration of the ones mattermost provides.

--- a/site/content/contribute/server/developer-setup.md
+++ b/site/content/contribute/server/developer-setup.md
@@ -45,3 +45,13 @@ For minimum software requirements, see the following table:
 <div id="centos" class="tabcontent">
     {{% content "contribute/server/developer-setup/centos.md" %}}
 </div>
+
+### Customize your workflow
+
+#### Makefile
+
+You can customize variables of the Makefile by creating a `config.override.mk` file or setting environment variables. To get started, you can copy the `config.mk` file and change the values in your newly copied file.
+
+#### Docker-compose
+
+If you create a `docker-compose.override.yaml` file at the root of the project, it will be automatically loaded by all the Makefile tasks using docker-compose, allowing you to define your own services or change the configuration of the one mattermost provides.

--- a/site/content/contribute/server/developer-setup.md
+++ b/site/content/contribute/server/developer-setup.md
@@ -50,7 +50,7 @@ For minimum software requirements, see the following table:
 
 #### Makefile
 
-You can customize variables of the Makefile by creating a `config.override.mk` file or setting environment variables. To get started, you can copy the `config.mk` file and change the values in your newly copied file.
+You can customize variables of the Makefile by creating a `config.override.mk` file or setting environment variables. To get started, you can copy the `config.mk` file to `config.override.mk` and change the values in your newly copied file.
 
 #### Docker-compose
 

--- a/site/content/contribute/server/developer-workflow.md
+++ b/site/content/contribute/server/developer-workflow.md
@@ -94,6 +94,16 @@ Optionally, you can assign that account System Admin rights with the following c
 mattermost user create --email user@example.com --username test1 --password mypassword --system_admin
 ```
 
+### Customize your workflow
+
+#### Makefile
+
+You can customize variables of the Makefile by creating a `config.override.mk` file or setting environment variables. To get started, you can copy the `config.mk` file to `config.override.mk` and change the values in your newly copied file.
+
+#### Docker-compose
+
+If you create a `docker-compose.override.yaml` file at the root of the project, it will be automatically loaded by all the `Makefile` tasks using `docker-compose`, allowing you to define your own services or change the configuration of the ones mattermost provides.
+
 ### Testing Email Notifications
 
 When Docker starts, the SMTP server is available on port 2500. A username and password are not required.


### PR DESCRIPTION
#### Summary
This PR adds some information about how to customize some variables from the Makefile and provides documentation on using a custom `docker-compose.override.yaml` file.

#### Ticket Link
N/A

