### PR TITLE
Fix header permalinks

### DIFF
--- a/site/static/css/bar.css
+++ b/site/static/css/bar.css
@@ -80,3 +80,7 @@
         right: 0px;
     }
 }
+
+html {
+    scroll-padding-top: 80px;
+}


### PR DESCRIPTION
#### Summary

Similar to https://github.com/mattermost/mattermost-developer-documentation/pull/857, this PR fixes the issue where the the navbar covers the header of a permalink.

#### Screenshots

When the "Workflow" header link is clicked:

Before

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/6913320/154193159-668f003e-3650-44b7-acec-6d93e59a889d.png">

After

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/6913320/154193125-c0cb05d4-0c70-46d9-b9a4-bd44ebd8681a.png">
