### PR TITLE
Remove link to deprecated core committers handbook page

### DIFF
--- a/site/content/contribute/getting-started/core-committers.md
+++ b/site/content/contribute/getting-started/core-committers.md
@@ -7,5 +7,3 @@ weight: 4
 ---
 
 A core committer is a maintainer on the Mattermost project that has merge access to Mattermost repositories. They are responsible for reviewing pull requests, cultivating the Mattermost developer community, and guiding the technical vision of Mattermost. 
-
-If you have a question or need some help, please visit the [Core Committers](https://handbook.mattermost.com/contributors/contributors/core-committers) page in the Mattermost Handbook.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Remove link to deprecated core committers handbook page.

