### PR TITLE
Minor fixes to Focalboard docs

### DIFF
--- a/site/content/contribute/focalboard/_index.md
+++ b/site/content/contribute/focalboard/_index.md
@@ -1,0 +1,36 @@
+---
+title: "Focalboard"
+heading: "Contribute to Focalboard"
+description: "Learn how to contribute to the Focalboard repository."
+date: 2022-03-24T00:40:23-07:00
+weight: 9
+---
+
+The [Focalboard](https://www.focalboard.com) / [Mattermost Boards](https://mattermost.com/boards) project is written in [TypeScript](https://www.typescriptlang.org/) and [Go](https://go.dev/).
+
+Like what you see? 👀 Help us make Focalboard even better! Follow these simple steps to make your experience as great as possible:
+
+1. Fork the [Focalboard repository](https://github.com/mattermost/focalboard), clone it locally, and follow the steps in the [Personal Server Setup Guide](personal-server-setup-guide) to build it. You can read the [changelog](https://github.com/mattermost/focalboard/blob/main/CHANGELOG.md) to get familiar with recent updates.
+
+2. Find [help wanted tickets that are up for grabs in GitHub](https://github.com/mattermost/focalboard/issues?q=is%3Aopen+is%3Aissue+label%3A%22Up+for+grabs%22+label%3A%22Help+Wanted%22). Comment to let everyone know you’re working on it and let a core contributor assign the issue to you. If there’s no ticket for what you want to work on, read about [contributions without a ticket](../getting-started/contributions-without-ticket).
+
+3. When your changes are checked in to your fork, follow the steps on our [contribution checklist](../getting-started/contribution-checklist). If this will be your first contribution, there is a standard [CLA](https://www.mattermost.org/mattermost-contributor-agreement/) that you will need to sign as part of this checklist.
+
+5. Submit your pull request for a [code review](../getting-started/code-review/#if-you-are-a-community-member-seeking-a-review) and [wait](../getting-started/code-review/#if-you-are-awaiting-a-review) for a [Focalboard core committer](https://github.com/mattermost/focalboard/blob/main/CONTRIBUTING.md#contributors) to review it. When in doubt, ask for help in the [Focalboard channel](https://community.mattermost.com/core/channels/focalboard) on our community server. If you are still stuck, please message Chen Lim ([@chenilim](https://github.com/chenilim) on GitHub).
+
+6. After a noteable bug fix or improvement is merged, submit a pull request to the [changelog](https://github.com/mattermost/focalboard/blob/main/CHANGELOG.md) under the next release section.
+
+We're glad ❤️ you're here! Good luck and have fun!
+
+## Repository
+
+https://github.com/mattermost/focalboard
+
+## Community
+
+You can join the [public Focalboard channel](https://community.mattermost.com/core/channels/focalboard) on our Mattermost community server. You can also [file a bug](https://github.com/mattermost/focalboard/issues/new/choose) for an issue or [start a discussion](https://github.com/mattermost/focalboard/discussions) on the repository.
+
+## Help Wanted
+
+You can find help wanted tickets [here](https://github.com/mattermost/focalboard/issues?q=is%3Aopen+is%3Aissue+label%3A%22Up+for+grabs%22+label%3A%22Help+Wanted%22).
+

--- a/site/content/contribute/focalboard/_index.md
+++ b/site/content/contribute/focalboard/_index.md
@@ -8,7 +8,7 @@ weight: 9
 
 The [Focalboard](https://www.focalboard.com) / [Mattermost Boards](https://mattermost.com/boards) project is written in [TypeScript](https://www.typescriptlang.org/) and [Go](https://go.dev/).
 
-Like what you see? 👀 Help us make Focalboard even better! Follow these simple steps to make your experience as great as possible:
+Here's the process for contributing to Focalboard:
 
 1. Fork the [Focalboard repository](https://github.com/mattermost/focalboard), clone it locally, and follow the steps in the [Personal Server Setup Guide](personal-server-setup-guide) to build it. You can read the [changelog](https://github.com/mattermost/focalboard/blob/main/CHANGELOG.md) to get familiar with recent updates.
 

--- a/site/content/contribute/focalboard/_index.md
+++ b/site/content/contribute/focalboard/_index.md
@@ -10,7 +10,7 @@ The [Focalboard](https://www.focalboard.com) / [Mattermost Boards](https://matte
 
 Here's the process for contributing to Focalboard:
 
-1. Fork the [Focalboard repository](https://github.com/mattermost/focalboard), clone it locally, and follow the steps in the [Personal Server Setup Guide](personal-server-setup-guide) to build it. You can read the [changelog](https://github.com/mattermost/focalboard/blob/main/CHANGELOG.md) to get familiar with recent updates.
+1. Fork the [Focalboard repository](https://github.com/mattermost/focalboard), clone it locally, and follow the steps in the [Personal Server Setup Guide](personal-server-setup-guide) to build it. You can read the [CHANGELOG](https://github.com/mattermost/focalboard/blob/main/CHANGELOG.md) to learn about recent updates.
 
 2. Find [help wanted tickets that are up for grabs in GitHub](https://github.com/mattermost/focalboard/issues?q=is%3Aopen+is%3Aissue+label%3A%22Up+for+grabs%22+label%3A%22Help+Wanted%22). Comment to let everyone know you’re working on it and let a core contributor assign the issue to you. If there’s no ticket for what you want to work on, read about [contributions without a ticket](../getting-started/contributions-without-ticket).
 
@@ -18,7 +18,7 @@ Here's the process for contributing to Focalboard:
 
 5. Submit your pull request for a [code review](../getting-started/code-review/#if-you-are-a-community-member-seeking-a-review) and [wait](../getting-started/code-review/#if-you-are-awaiting-a-review) for a [Focalboard core committer](https://github.com/mattermost/focalboard/blob/main/CONTRIBUTING.md#contributors) to review it. When in doubt, ask for help in the [Focalboard channel](https://community.mattermost.com/core/channels/focalboard) on our community server. If you are still stuck, please message Chen Lim ([@chenilim](https://github.com/chenilim) on GitHub).
 
-6. After a noteable bug fix or improvement is merged, submit a pull request to the [changelog](https://github.com/mattermost/focalboard/blob/main/CHANGELOG.md) under the next release section.
+6. After a noteable bug fix or improvement is merged, submit a pull request to the [CHANGELOG](https://github.com/mattermost/focalboard/blob/main/CHANGELOG.md) under the next release section.
 
 We're glad ❤️ you're here! Good luck and have fun!
 

--- a/site/content/contribute/focalboard/mattermost-boards-setup-guide.md
+++ b/site/content/contribute/focalboard/mattermost-boards-setup-guide.md
@@ -1,0 +1,55 @@
+---
+title: "Mattermost Boards Plugin Guide"
+heading: "Mattermost Boards Plugin Guide"
+description: "Learn how to build the Mattermost Boards plugin."
+date: 2022-03-24T00:40:23-07:00
+weight: 2
+---
+
+**[Mattermost Boards](https://mattermost.com/boards/)** is the Mattermost plugin version of Focalboard that combines project management tools with messaging and collaboration for teams of all sizes. It is installed and enabled by default in Mattermost v6.0 and later. For working with Focalboard as a standalone application, please refer to the [Personal Server Setup Guide](../personal-server-setup-guide/).
+
+## Building the plugin
+
+Fork the [Focalboard repository](https://github.com/mattermost/focalboard) and clone it locally.
+
+To install the dependencies:
+```
+cd mattermost-plugin/webapp
+npm install --no-optional
+cd ../..
+make prebuild
+```
+
+To build the plugin:
+```
+make webapp
+cd mattermost-plugin
+make dist
+```
+
+Refer to the [dev-release.yml](https://github.com/mattermost/focalboard/blob/main/.github/workflows/dev-release.yml#L168) workflow for the up-to-date commands that are run as part of CI.
+
+## Uploading and installing the plugin
+
+1. Enable [custom plugins](https://developers.mattermost.com/integrate/admin-guide/admin-plugins-beta/#custom-plugins) by setting `PluginSettings.EnableUploads` to `true` and set `FileSettings.MaxFileSize` to a number larger than the size of the packed`.tar.gz` plugin file in bytes (e.g., `524288000`) in the Mattermost `config.json` file.
+2. Navigate to **System Console > Plugins > Management** and upload the packed `.tar.gz` file from your `mattermost-plugin/dist` directory.
+3. Enable the plugin.
+
+## Deploying the plugin to a local Mattermost server
+
+Instead of following the steps above, you can also set up a `mattermost-server` in local mode and automatically deploy `mattermost-plugin` via `make deploy`.
+
+* Follow the steps in the [`mattermost-webapp` developer setup guide](https://developers.mattermost.com/contribute/webapp/developer-setup/) and then:
+  * Open a new terminal window. In this terminal window, add an environmental variable to your bash via `MM_SERVICESETTINGS_SITEURL='http://localhost:8065'` ([docs](https://developers.mattermost.com/blog/subpath/#using-subpaths-in-development))
+  * Build the web app via `make build`
+* Follow the steps in the [`mattermost-server` developer setup guide](https://developers.mattermost.com/contribute/server/developer-setup/) and then:
+  * Make sure Docker is running.
+  * Run `make config-reset` to generate the `config/config.json` file:
+    * Edit `config/config.json`:
+      * Set `ServiceSettings > SiteURL` to `http://localhost:8065` ([docs](https://docs.mattermost.com/configure/configuration-settings.html#site-url))
+      * Set `ServiceSettings > EnableLocalMode` to `true` ([docs](https://docs.mattermost.com/configure/configuration-settings.html#enable-local-mode))
+      * Set `PluginSettings > EnableUploads` to `true` ([docs](https://developers.mattermost.com/integrate/admin-guide/admin-plugins-beta/#custom-plugins))
+  * In this terminal window, add an environmental variable to your bash via `MM_SERVICESETTINGS_SITEURL='http://localhost:8065'` ([docs](https://developers.mattermost.com/blog/subpath/#using-subpaths-in-development))
+  * Build and run the server via `make run-server`
+* Follow the [steps above](#building-the-plugin) to install the dependencies.
+* Run `make deploy` in the `mattermost-plugin` folder to automatically deploy your plugin to your local Mattermost server.

--- a/site/content/contribute/focalboard/personal-server-setup-guide.md
+++ b/site/content/contribute/focalboard/personal-server-setup-guide.md
@@ -47,13 +47,13 @@ To run the server:
  ./bin/focalboard-server
 ```
 
-Then navigate your browser to `[http://localhost:8000](http://localhost:8000)` to access your Focalboard server. The port is configured in `config.json`.
+Then navigate your browser to [`http://localhost:8000`](http://localhost:8000) to access your Focalboard server. The port is configured in `config.json`.
 
 Once the server is running, you can rebuild just the web app via `make webapp` in a separate terminal window. Reload your browser to see the changes.
 
 ## Building and running standalone desktop apps
 
-You can build standalone apps that package the server to run locally against SQLite:
+You can build standalone apps that package the server to run locally against [SQLite](https://www.sqlite.org/index.html):
 
 * **Windows**:
     * *Requires Windows 10, [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/) 10.0.19041.0, and .NET 4.8 developer pack*
@@ -84,7 +84,7 @@ Cross-compilation currently isn't fully supported, so please build on the approp
 
 ## Setting up VS Code
 
-* Open a VS Code terminal window in the project folder.
+* Open a [VS Code](https://code.visualstudio.com/) terminal window in the project folder.
 * Run `make prebuild` to install packages. *Do this whenever dependencies change in `webapp/package.json`.*
 * Run `cd webapp && npm run watchdev` to automatically rebuild the web app when files are changed. It also includes source maps from JavaScript to TypeScript.
 * Install the [Go](https://marketplace.visualstudio.com/items?itemName=golang.Go) and [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) VS Code extensions (if you haven't already).
@@ -123,7 +123,7 @@ Run `make ci`, which is similar to the `.gitlab-ci.yml` workflow and includes:
 
 Are you interested in influencing the future of the Focalboard open source project? Please read the [Focalboard Contribution Guide](../). We welcome everyone and appreciate any feedback. ❤️ There are several ways you can get involved:
 
-* **Changelog**: See [CHANGELOG.md](CHANGELOG.md) for the latest updates
+* **Changes**: See the [CHANGELOG](https://github.com/mattermost/focalboard/blob/main/CHANGELOG.md) for the latest updates
 * **GitHub Discussions**: Join the [Developer Discussion](https://github.com/mattermost/focalboard/discussions) board
 * **Bug Reports**: [File a bug report](https://github.com/mattermost/focalboard/issues/new?assignees=&labels=bug&template=bug_report.md&title=)
 * **Chat**: Join the [Focalboard community channel](https://community.mattermost.com/core/channels/focalboard)

--- a/site/content/contribute/focalboard/personal-server-setup-guide.md
+++ b/site/content/contribute/focalboard/personal-server-setup-guide.md
@@ -1,0 +1,129 @@
+---
+title: "Personal Server Setup Guide"
+heading: "Personal Server Setup Guide"
+description: "Learn how to build the Focalboard Personal Server."
+date: 2022-03-24T00:40:23-07:00
+weight: 1
+---
+
+This guide will help you configure your developer environment for the Focalboard **Personal Server**. For most features, this is the easiest way to get started working against code that ships across editions. For working with **Mattermost Boards** (Focalboard as a plugin), please refer to the [Mattermost Boards Plugin Guide](../mattermost-boards-setup-guide/).
+
+## Installing prerequisites
+### All
+* [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) (if using Windows, see below)
+* [Go](https://golang.org/doc/install)
+* [Node.js](https://nodejs.org/en/download/) (v10+)
+* [npm](https://www.npmjs.com/get-npm)
+
+### Windows
+* Install [MinGW-w64](https://chocolatey.org/packages/mingw) via [Chocolatey](https://chocolatey.org/)
+* Install [Git for Windows](https://gitforwindows.org/) and use the `git-bash` terminal shell
+
+### Mac
+* Install [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) (v12+)
+* Install the Xcode Command Line Tools via `xcode-select --install`
+
+### Linux
+* `sudo apt-get install libgtk-3-dev`
+* `sudo apt-get install libwebkit2gtk-4.0-dev`
+* `sudo apt-get install autoconf dh-autoreconf`
+
+## Forking the project repository
+
+Fork the [Focalboard GitHub repository](https://github.com/mattermost/focalboard) and clone it locally.
+
+## Building via the terminal
+
+To build the server:
+
+```
+make prebuild
+make
+```
+
+To run the server:
+
+```
+ ./bin/focalboard-server
+```
+
+Then navigate your browser to `[http://localhost:8000](http://localhost:8000)` to access your Focalboard server. The port is configured in `config.json`.
+
+Once the server is running, you can rebuild just the web app via `make webapp` in a separate terminal window. Reload your browser to see the changes.
+
+## Building and running standalone desktop apps
+
+You can build standalone apps that package the server to run locally against SQLite:
+
+* **Windows**:
+    * *Requires Windows 10, [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/) 10.0.19041.0, and .NET 4.8 developer pack*
+    * Open a `git-bash` prompt.
+    * Run `make win-wpf-app`
+    * Run `cd win-wpf/msix && focalboard.exe`
+* **Mac**:
+    * *Requires macOS 11.3+ and Xcode 13.2.1+*
+    * `make mac-app`
+    * `open mac/dist/Focalboard.app`
+* **Linux**:
+    * *Tested on Ubuntu 18.04*
+    * Install `webgtk` dependencies
+        * `sudo apt-get install libgtk-3-dev`
+        * `sudo apt-get install libwebkit2gtk-4.0-dev`
+    * `make linux-app`
+    * Uncompress `linux/dist/focalboard-linux.tar.gz` to a directory of your choice
+    * Run `focalboard-app` from the directory you have chosen
+* **Docker**:
+    * To run it locally from offical image:
+        * `docker run -it -p 80:8000 mattermost/focalboard`
+    * To build it for your current architecture:
+        * `docker build -f docker/Dockerfile .`
+    * To build it for a custom architecture (experimental):
+        * `docker build -f docker/Dockerfile --platform linux/arm64 .`
+
+Cross-compilation currently isn't fully supported, so please build on the appropriate platform. Refer to the GitHub Actions workflows (`build-mac.yml`, `build-win.yml`, `build-ubuntu.yml`) for the detailed list of steps on each platform.
+
+## Setting up VS Code
+
+* Open a VS Code terminal window in the project folder.
+* Run `make prebuild` to install packages. *Do this whenever dependencies change in `webapp/package.json`.*
+* Run `cd webapp && npm run watchdev` to automatically rebuild the web app when files are changed. It also includes source maps from JavaScript to TypeScript.
+* Install the [Go](https://marketplace.visualstudio.com/items?itemName=golang.Go) and [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) VS Code extensions (if you haven't already).
+* Launch the server:
+    * **Windows**: `Ctrl+P`, type `debug`, press the `Space` key, and select `Go: Launch Server`.
+    * **Mac**: `Cmd+P`, type `debug`, press the `Space` key, and select `Go: Launch Server`.
+    * *If you do not see `Go: Launch Server` as an option, check your `./.vscode/launch.json` file and make sure you are not using a VS Code workspace.*
+* Navigate a browser to `http://localhost:8000`
+
+You can now edit the web app code and refresh the browser to see your changes efficiently.
+
+**Debugging the web app**: As a starting point, add a breakpoint to the `render()` function in `BoardPage.tsx` and refresh the browser to walk through page rendering.
+
+**Debugging the server**: As a starting point, add a breakpoint to `handleGetBlocks()` in `server/api/api.go` and refresh the browser to see how data is retrieved.
+
+## Rebuilding translations
+
+We use `i18n` to localize the web app. Localized string generally use `intl.formatMessage`. When adding or modifying localized strings, run `npm run i18n-extract` in `webapp` to rebuild `webapp/i18n/en.json`.
+
+Translated strings are stored in other json files under `webapp/i18n`, (e.g. `es.json` for Spanish).
+
+## Accessing the database
+
+By default, data is stored in a sqlite database `focalboard.db`. You can view and edit this directly using `sqlite3 focalboard.db`.
+
+## Unit testing
+
+Run `make ci`, which is similar to the `.gitlab-ci.yml` workflow and includes:
+
+* **Server unit tests**: `make server-test`
+* **Web app ESLint**: `cd webapp; npm run check`
+* **Web app unit tests**: `cd webapp; npm run test`
+* **Web app UI tests**: `cd webapp; npm run cypress:ci`
+
+## Staying informed
+
+Are you interested in influencing the future of the Focalboard open source project? Please read the [Focalboard Contribution Guide](../). We welcome everyone and appreciate any feedback. ❤️ There are several ways you can get involved:
+
+* **Changelog**: See [CHANGELOG.md](CHANGELOG.md) for the latest updates
+* **GitHub Discussions**: Join the [Developer Discussion](https://github.com/mattermost/focalboard/discussions) board
+* **Bug Reports**: [File a bug report](https://github.com/mattermost/focalboard/issues/new?assignees=&labels=bug&template=bug_report.md&title=)
+* **Chat**: Join the [Focalboard community channel](https://community.mattermost.com/core/channels/focalboard)

--- a/site/content/contribute/getting-started/_index.md
+++ b/site/content/contribute/getting-started/_index.md
@@ -17,6 +17,7 @@ The Mattermost core repositories include:
 * [Mobile Apps]({{< ref "/contribute/mobile" >}}) - JavaScript client apps for Android and iOS built on React Native
 * [Desktop App]({{< ref "/contribute/desktop" >}}) - An Electron wrapper around the web app project that runs on Windows, Linux, and macOS
 * [Core Plugins]({{< ref "/contribute/plugins" >}}) - A core set of officially-maintained plugins that provide a variety of improvements to Mattermost.
+* Core Integrations - Major Mattermost features including [Focalboard]({{< ref "/contribute/focalboard" >}}) and [Playbooks](https://github.com/mattermost/mattermost-plugin-playbooks).
 
 Improvements to Mattermost may require you to contribute to multiple projects; if you’re unsure where to start, the server repository is generally the best way to get introduced to the codebase.
 

--- a/site/content/contribute/getting-started/_index.md
+++ b/site/content/contribute/getting-started/_index.md
@@ -25,7 +25,7 @@ Improvements to Mattermost may require you to contribute to multiple projects; i
 
 If you’re looking for an existing issue to help with, check out the [help wanted tickets on GitHub](https://mattermost.com/pl/help-wanted). If you see any that you’re interested in working on, comment on it to let everyone know you’re working on it. If there’s no ticket for what you want to contribute, see our guide on [contributing without a ticket.]({{< ref "contributions-without-ticket.md" >}})
 
-Once you’ve created some code that you want to contribute, follow our [pull request checklist]({{< ref "contribution-checklist.md" >}}) to submit your contribution for [review]({{< ref "code-review.md" >}}), and one of our [core committers](https://handbook.mattermost.com/contributors/contributors/core-committers) will reach out with any feedback, questions, or requests they have.
+Once you’ve created some code that you want to contribute, follow our [pull request checklist]({{< ref "contribution-checklist.md" >}}) to submit your contribution for [review]({{< ref "code-review.md" >}}), and one of our [core committers](core-committers/) will reach out with any feedback, questions, or requests they have.
 
 
 ## How to Get Help With Your Contribution

--- a/site/content/integrate/plugins/community_process.md
+++ b/site/content/integrate/plugins/community_process.md
@@ -8,7 +8,7 @@ aliases: [/extend/plugins/community_process/]
 ---
 
 
-Getting your plugin onto our Community server https://community.mattermost.com is a valuable source of feedback. Whether you're a [Core Committer](https://github.com/mattermost/mattermost-developer-documentation/blob/dae9ecb3b445111479acbaba9f382e9eb263bc52/contribute/getting-started/core-committers) or anyone from the community, we want you to get feedback to improve your plugin. 
+Getting your plugin onto our Community server https://community.mattermost.com is a valuable source of feedback. Whether you're a [core committer](/contribute/getting-started/core-committers/) or anyone from the community, we want you to get feedback to improve your plugin. 
 
 However we must ensure that our Community server remains stable for everyone. This document outlines the process of getting your plugin onto the Community server and some of these steps are required to get your plugin into the [Marketplace]({{< ref "/integrate/plugins/community-plugin-marketplace" >}}). 
 


### PR DESCRIPTION
#### Summary
This PR accompanies #1050. It fixes a Markdown link, adds two more relevant links, and makes the language more consistent. This should wrap up the Focalboard doc migration!