### PR TITLE
update: focalboard instructions for prebuild for standalone desktop app dev setup

### DIFF
--- a/site/content/contribute/focalboard/personal-server-setup-guide.md
+++ b/site/content/contribute/focalboard/personal-server-setup-guide.md
@@ -58,18 +58,27 @@ You can build standalone apps that package the server to run locally against [SQ
 * **Windows**:
     * *Requires Windows 10, [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/) 10.0.19041.0, and .NET 4.8 developer pack*
     * Open a `git-bash` prompt.
+    * Run `make prebuild`
+    * The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
+    * Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
     * Run `make win-wpf-app`
     * Run `cd win-wpf/msix && focalboard.exe`
 * **Mac**:
     * *Requires macOS 11.3+ and Xcode 13.2.1+*
-    * `make mac-app`
-    * `open mac/dist/Focalboard.app`
+    * Run `make prebuild`
+    * The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
+    * Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
+    * Run `make mac-app`
+    * Run `open mac/dist/Focalboard.app`
 * **Linux**:
     * *Tested on Ubuntu 18.04*
     * Install `webgtk` dependencies
-        * `sudo apt-get install libgtk-3-dev`
-        * `sudo apt-get install libwebkit2gtk-4.0-dev`
-    * `make linux-app`
+        * Run `sudo apt-get install libgtk-3-dev`
+        * Run `sudo apt-get install libwebkit2gtk-4.0-dev`
+    * Run `make prebuild`
+    * The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
+    * Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
+    * Run `make linux-app`
     * Uncompress `linux/dist/focalboard-linux.tar.gz` to a directory of your choice
     * Run `focalboard-app` from the directory you have chosen
 * **Docker**:


### PR DESCRIPTION
#### Summary

Updated the [focalboard documentation](https://developers.mattermost.com/contribute/focalboard/personal-server-setup-guide/#building-and-running-standalone-desktop-apps) to inform the developer to run the `make prebuild` step before the `make linux-app` or `make win-wpf-app` or `make mac-app` step.

#### Ticket Link
Related issue #1079

Signed-off by: imasdekar <imasdekar@disroot.org>

