### PR TITLE
We are using any instead of interface{} now, min Go version is 1.18

### DIFF
--- a/site/content/contribute/server/developer-setup.md
+++ b/site/content/contribute/server/developer-setup.md
@@ -16,7 +16,7 @@ For minimum software requirements, see the following table:
 |----------------|------------------|
 | Docker         | 17.12.0+         |
 | Docker Compose | 1.21.0+          |
-| Go             | 1.16.0+          |
+| Go             | 1.18.0+          |
 
 <div class="tab">
     <button class="tablinks active" onclick="openTab(event, 'mac')">Mac OS X</button>


### PR DESCRIPTION
#### Summary
The change from `interface{}` to `any` requires developers to use Go 1.18 or higher
