### PR TITLE
Fix preview environment for forked PRs

### DIFF
--- a/.github/workflows/preview-env-fork.yml
+++ b/.github/workflows/preview-env-fork.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build Previews
         run: |
           rm -rf ./dist
-          hugo -F -s site --baseURL http://mattermost-dev-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/ --destination ../dist/html
+          hugo -F -s site --baseURL http://mattermost-dev-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/${{ steps.pr.outputs.id }} --destination ../dist/html
 
       - uses: shallwefootball/s3-upload-action@master
         name: Upload Preview Env

--- a/.github/workflows/preview-env-fork.yml
+++ b/.github/workflows/preview-env-fork.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build Previews
         run: |
           rm -rf ./dist
-          hugo -F -s site --baseURL http://mattermost-dev-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/${{ steps.pr.outputs.id }} --destination ../dist/html
+          hugo -F -s site --baseURL http://mattermost-dev-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/${{ steps.pr.outputs.id }}/ --destination ../dist/html
 
       - uses: shallwefootball/s3-upload-action@master
         name: Upload Preview Env


### PR DESCRIPTION
#### Summary
BaseURL is incorrect for forked PRs that causes preview environment has incorrect base url and that will broke static asset links.

