### PR TITLE
Remove storybook step from local e2e setup

### DIFF
--- a/site/content/contribute/more-info/webapp/e2e/running-e2e.md
+++ b/site/content/contribute/more-info/webapp/e2e/running-e2e.md
@@ -34,7 +34,7 @@ Environment variables are [defined in cypress.json](https://github.com/mattermos
 1.  Launch a local Mattermost instance by running `make run` in the `mattermost-server` directory. Confirm that the Mattermost instance has started successfully.
     - Run `make test-data` to preload your server instance with initial seed data.
     - Each test case should handle the required system or user settings, but in case you encounter an unexpected error while testing, you may want to run the server with default config based on `mattermost-server/config/default.json`.
-    - In another terminal, in the `mattermost-webapp` directory, run `npm run storybook`. This is required for the Cypress tests which run against the Storybook widgets to pass.
+
 2.  Change directory to `mattermost-webapp/e2e/cypress`, and install npm dependencies by running `npm i`.
     - Initiate `npm run cypress:run` in the command line to start full E2E testing. This excludes the specs in the `/cypress/tests/integration/enterprise` folder as they require an Enterprise license to run successfully.
     - Initiate `npm run cypress:open` in the command line to start partial testing depending on which spec is selected via Cypress's desktop app.


### PR DESCRIPTION


#### Summary
We have removed the storybook from the mattermost-webapp, so this step isn't required anymore.
Confusing for new contributors.
https://community.mattermost.com/core/pl/j6jx6c9oapggdezs31dukkmfry

#### Ticket Link
NA





