### PR TITLE
Auto-expand subtopics in sidebar for the Contribute section

### DIFF
--- a/site/layouts/partials/sidebar.html
+++ b/site/layouts/partials/sidebar.html
@@ -9,6 +9,9 @@
             {{ range .Pages.ByWeight }}
                 {{ $active := (eq $ .) }}
                 {{ $expanded := or ($.IsDescendant .) (eq $ .) }}
+                {{ if (eq .Section "contribute") }}
+                    {{ $expanded = true }}
+                {{ end }}
 
                 {{ $icon :=  "fa-plus-square-o" }}
                 {{ if $expanded }}
@@ -16,7 +19,7 @@
                 {{ end }}
 
                 {{ $iconstyle := "" }}
-                {{if not .Pages }}
+                {{ if not .Pages }}
                     {{ $iconstyle = "display: none" }}
                 {{ end }}
 


### PR DESCRIPTION
#### Summary
This PR will auto-expand subtopics in the sidebar for pages in the Contribute section only. The Integrate section is not affected.
