### PR TITLE
Wrong Golang Link In WSL Setup

### DIFF
--- a/site/content/contribute/more-info/server/developer-setup/windows-wsl.md
+++ b/site/content/contribute/more-info/server/developer-setup/windows-wsl.md
@@ -44,7 +44,7 @@ This is an unofficial guide. Community testing, feedback, and improvements are w
     sudo chmod +x /usr/local/bin/docker-compose
     ```
 
-3. Install Go using bash (modify installation to latest Go version from https://golang.org/dl/):
+3. Install Go using bash (modify installation to latest Go version from https://go.dev/dl/):
 
     ```sh
     sudo apt-get install -y build-essential


### PR DESCRIPTION

#### Summary
In the [Setting Up Your Development Environment](https://developers.mattermost.com/contribute/more-info/server/developer-setup/) page, under the Windows WSL section, when you get to step 4, it states:

> Install Go using bash (modify installation to latest Go version from https://golang.org/dl/):

This link does not work anymore and I changed it to https://go.dev/dl/.

#### Ticket Link
  Fixes #1158 

