### PR TITLE
chore(webapp): added note for apple silicon macs

### DIFF
--- a/site/content/contribute/more-info/webapp/developer-setup.md
+++ b/site/content/contribute/more-info/webapp/developer-setup.md
@@ -45,6 +45,14 @@ Set up your development environment for building, running, and testing the Matte
         brew install libpng
         ```
 
+        {{<note "Note:">}}
+If you are working with an [Apple Silicon Mac](https://support.apple.com/en-us/HT211814) you may need to install rosetta for dependencies not ready to work in an ARM machine to work properly:
+
+```sh
+softwareupdate --install-rosetta
+```
+        {{</note>}}
+
     - On Linux-based operating systems, use your preferred package manager to install it.
 
 7. Ensure that the mattermost server [is running]({{< ref "/contribute/more-info/server/developer-setup" >}}). If it's not, open a new terminal session, navigate into the `mattermost-server` directory, and start the server:

--- a/site/content/contribute/more-info/webapp/developer-setup.md
+++ b/site/content/contribute/more-info/webapp/developer-setup.md
@@ -46,7 +46,7 @@ Set up your development environment for building, running, and testing the Matte
         ```
 
         {{<note "Note:">}}
-If you are working with an [Apple Silicon Mac](https://support.apple.com/en-us/HT211814) you may need to install rosetta for dependencies not ready to work in an ARM machine to work properly:
+If you are working with an {{<newtabref title="Apple Silicon Mac" href="https://support.apple.com/en-us/HT211814">}} you may need to install rosetta for dependencies not ready to work in an ARM machine to work properly:
 
 ```sh
 softwareupdate --install-rosetta


### PR DESCRIPTION
#### Summary
Added a note regarding Apple Silicon Macs requiring Rosetta to be installed for al package.json dependencies and libraries to work ok.

I didn't find any Apple oficial documentation regarding the `softwareupdate` command, that's why I just put it in there.

<!-- related mattermost thread: https://community.mattermost.com/core/pl/ntq46e5mgir4xcd65ofnym3aeo -->