### PR TITLE
Removed $ signs so the commands can be copied with the UI copy button

### DIFF
--- a/site/content/contribute/more-info/mobile/developer-setup/_index.md
+++ b/site/content/contribute/more-info/mobile/developer-setup/_index.md
@@ -38,7 +38,7 @@ We recommend using npm version 7 (with either Node 15 or 16). To make switching 
 - To install using Homebrew open a terminal and execute:
 
 ```sh
-    $ brew install nvm
+    brew install nvm
 ```
 
 ##### Linux
@@ -62,7 +62,7 @@ The minimum required version is 4.9.0.
 - To install using Homebrew open a terminal and execute:
 
     ```sh
-    $ brew install watchman
+      brew install watchman
     ```
 
 ##### Linux
@@ -76,7 +76,7 @@ The minimum required version is 4.9.0.
 #### Install `react-native-cli` tools
 
 ```sh
-$ npm -g install react-native-cli
+  npm -g install react-native-cli
 ```
 #### Install Ruby
 ##### Windows 10
@@ -88,7 +88,7 @@ $ npm -g install react-native-cli
 #### Install `bundler --version 2.0.2` gem
 
 ```sh
-$ gem install bundler --version 2.0.2
+  gem install bundler --version 2.0.2
 ```
 #### Obtaining the source code
 
@@ -97,7 +97,7 @@ We use GitHub to host the source code so we recommend that you install [Git](htt
 ##### macOS
 
 ```sh
-$ brew install git
+  brew install git
 ```
 
 ##### Linux
@@ -228,5 +228,5 @@ Check the following things:
 * Ensure you are running the latest version of `nvm` using the [Upgrade Instructions](https://github.com/nvm-sh/nvm#install--update-script)
 * Ensure you have set your desired version of node in the file `~/.nvmrc`.  E.g.,
     ```sh
-    $ echo v16.2.0 > ~/.nvmrc
+      echo v16.2.0 > ~/.nvmrc
     ```


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Right now the `$` sign was copied from the highlighted command in the UI, so when you want to execute it won't work right away.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

