### PR TITLE
Add missing feedback widget to the rest of the docs pages

### DIFF
--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -30,5 +30,6 @@
         </div>
     </div>
     {{ partial "footer.html" .}}
+    {{ partial "feedback.html" . }}
 </body>
 </html>


### PR DESCRIPTION
#### Summary
The feedback widget is missing from several docs pages. This PR resolves the issue by adding the feedback widget code to the docs template that was not modified during the original implementation.