### PR TITLE
App oauth2 example fix url

### DIFF
--- a/site/content/integrate/apps/authentication/app-to-third-party/_index.md
+++ b/site/content/integrate/apps/authentication/app-to-third-party/_index.md
@@ -7,7 +7,7 @@ aliases:
   - /integrate/apps/using-third-party-api/hello-oauth2/
 ---
 
-This is an example of an HTTP app ({{< newtabref href="https://github.com/mattermost/mattermost-plugin-apps/tree/master/examples/go/hello-oauth2" title="source" >}}), written in Go and runnable on `http://localhost:8082`.
+This is an example of an HTTP app ({{< newtabref href="https://github.com/mattermost/mattermost-app-examples/tree/master/golang/oauth2" title="source" >}}), written in Go and runnable on `http://localhost:8082`.
 
 - It contains a `manifest.json`, declares itself an HTTP application, requests permissions, and binds itself to locations in the Mattermost user interface.
 - In its `bindings` function it declares three commands: `configure`, `connect`, and `send`.
@@ -52,7 +52,7 @@ Hello OAuth2! is an HTTP app, it requests the *permissions* to act as a System A
 	"display_name": "Hello, OAuth2!",
 	"app_type": "http",
 	"icon": "icon.png",
-	"homepage_url": "https://github.com/mattermost/mattermost-app-examples/golang/oauth2",
+	"homepage_url": "https://github.com/mattermost/mattermost-app-examples/tree/master/golang/oauth2",
 	"requested_permissions": [
 		"act_as_user",
 		"remote_oauth2"

--- a/site/content/integrate/apps/authentication/app-to-third-party/_index.md
+++ b/site/content/integrate/apps/authentication/app-to-third-party/_index.md
@@ -20,9 +20,9 @@ To install "Hello, OAuth2" on a locally-running instance of Mattermost follow th
 Make sure you have followed the Quick Start Guide [prerequisite steps]({{< ref quick-start-go >}}).
 
 ```sh
-git clone https://github.com/mattermost/mattermost-plugin-apps.git
-cd mattermost-plugin-apps/examples/go/hello-oauth2
-go run
+git clone https://github.com/mattermost/mattermost-app-examples.git
+cd mattermost-app-examples/golang/oauth2
+go run hello.go
 ```
 
 Run the following Mattermost slash command:
@@ -52,7 +52,7 @@ Hello OAuth2! is an HTTP app, it requests the *permissions* to act as a System A
 	"display_name": "Hello, OAuth2!",
 	"app_type": "http",
 	"icon": "icon.png",
-	"homepage_url": "https://github.com/mattermost/mattermost-plugin-apps/examples/go/hello-oauth2",
+	"homepage_url": "https://github.com/mattermost/mattermost-app-examples/golang/oauth2",
 	"requested_permissions": [
 		"act_as_user",
 		"remote_oauth2"


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

The hello-oauth example is no longer in the specified URL in the documentation, replaced for the right one.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

