### PR TITLE
Correct typo in `docker-compose` command

### DIFF
--- a/site/content/integrate/apps/quickstart/quick-start-go/_index.md
+++ b/site/content/integrate/apps/quickstart/quick-start-go/_index.md
@@ -26,7 +26,7 @@ In the same {{< newtabref href="https://github.com/mattermost/mattermost-app-exa
 
 ```sh
 cd golang/hello-world
-docker compose up
+docker-compose up
 ```
 
 You'll see Docker install the Go modules and then the App will come online and print the following message:


### PR DESCRIPTION
#### Summary

Corrects a typo in the command to start the docker-compose stack. `docker compose up` is not a valid Docker command, meanwhile `docker-compose up` is a valid `docker-compose` command.

#### Ticket Link
n/a
