### PR TITLE
Remove notification bar

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -31,9 +31,9 @@ enableEmoji=true
     enable = false
 
   [params.notification]
-    enable = true
-    url = "https://mattermost.com/webinar/release-management-with-gitlab/"
-    text = "Learn how to streamline and standardize your release processes with Mattermost and GitLab on March 2nd »"
+    enable = false
+    url = ""
+    text = ""
 
   [params.search]
     enable = true

--- a/site/layouts/partials/notification.html
+++ b/site/layouts/partials/notification.html
@@ -1,14 +1,4 @@
 {{ if .Site.Params.notification.enable }}
-<!-- <div class='notification-bar sticky-top'>
-    <div class="notification-bar__content">
-        <a class="notification-bar__close">
-            <span aria-hidden="true">×</span>
-        </a>
-        <a href="{{ .Site.Params.notification.url | absURL }}">
-            {{ .Site.Params.notification.text }}
-        </a>
-    </div>
-</div> -->
 <div data-swiftype-index=false class="notification-bar">
     <div class="notification-bar__content">
         <a class="notification-bar__close" data-ol-has-click-handler="">


### PR DESCRIPTION
#### Summary
This PR removes the notification banner since the GitLab webinar has passed. A discussion re: a general fallback is being had.

Thanks!



