### PR TITLE
Remove underscore from action id

### DIFF
--- a/site/content/integrate/plugins/interactive-messages/_index.md
+++ b/site/content/integrate/plugins/interactive-messages/_index.md
@@ -120,7 +120,7 @@ Similar to buttons, add message menus as `actions` in your integration [message 
 
 ![image](message-menus.png)
 
-The following payload gives an example that uses message menus.
+The following payload gives an example that uses message menus (please note that the id in the actions array may only consist of letters and numbers, no other characters are allowed!):
 
 ```json
 {
@@ -130,10 +130,10 @@ The following payload gives an example that uses message menus.
       "text": "This is the attachment text.",
       "actions": [
         {
-          "id": "action_options",
+          "id": "actionoptions",
           "name": "Select an option...",
           "integration": {
-            "url": "http://127.0.0.1:7357/action_options",
+            "url": "http://127.0.0.1:7357/actionoptions",
             "context": {
               "action": "do_something"
             }
@@ -186,10 +186,10 @@ Specify `channels` as your action's `data_source` as follows:
       "text": "This is the attachment text.",
       "actions": [
         {
-          "id": "action_options",
+          "id": "actionoptions",
           "name": "Select an option...",
           "integration": {
-            "url": "http://127.0.0.1:7357/action_options",
+            "url": "http://127.0.0.1:7357/actionoptions",
             "context": {
               "action": "do_something"
             }
@@ -213,14 +213,14 @@ Specify `users` as your action's `data_source` as follows:
 {
   "attachments": [
     {
-      "id": "action_options",
+      "id": "actionoptions",
       "pretext": "This is the attachment pretext.",
       "text": "This is the attachment text.",
       "actions": [
         {
           "name": "Select an option...",
           "integration": {
-            "url": "http://127.0.0.1:7357/action_options",
+            "url": "http://127.0.0.1:7357/actionoptions",
             "context": {
               "action": "do_something"
             }


### PR DESCRIPTION
According to https://mattermost.atlassian.net/browse/MM-49350, underscores are not allowed in action ids. I stumbled upon that some time ago and a [user in the forums](https://forum.mattermost.com/t/interactive-message-menu-not-returning-value/10841/10) brought this issue back to my attention, so here's a fix for the documentation, at least to make sure the docs have a hint about that and users (like me) don't copy a broken example config.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

