### PR TITLE
Removed unnecessary commas in JSON examples

### DIFF
--- a/site/content/integrate/apps/structure/forms/_index.md
+++ b/site/content/integrate/apps/structure/forms/_index.md
@@ -174,7 +174,7 @@ If a form was not included with the command binding, the binding's call will be 
             }
         ],
         "submit": {
-            "path": "/sub",
+            "path": "/sub"
         }
     }
 }
@@ -220,7 +220,7 @@ If a form was not included with the command binding, the binding's call will be 
             }
         ],
         "submit": {
-            "path": "/sub",
+            "path": "/sub"
         }
     }
 }


### PR DESCRIPTION
Some of the commas provided in the sample JSON objects broke the json syntax. The commas have been removed.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

