### PR TITLE
Add Makefile target to update development Docker container configuration

### DIFF
--- a/site/content/contribute/monorepo-migration-notes.md
+++ b/site/content/contribute/monorepo-migration-notes.md
@@ -22,3 +22,9 @@ Then:
     cp ../../mattermost-server-old/config.override.mk ./
     ```
 
+1. Update your development Docker containers for the new location of the server folder
+
+    ```sh
+    cd server
+    make update-docker
+    ```

--- a/site/content/contribute/monorepo-migration-notes.md
+++ b/site/content/contribute/monorepo-migration-notes.md
@@ -22,7 +22,7 @@ Then:
     cp ../../mattermost-server-old/config.override.mk ./
     ```
 
-1. Update your development Docker containers for the new location of the server folder
+1. Update your development Docker containers for the new location of the server folder:
 
     ```sh
     cd server

--- a/site/content/contribute/more-info/server/developer-workflow.md
+++ b/site/content/contribute/more-info/server/developer-workflow.md
@@ -68,6 +68,7 @@ Some useful `make` commands include:
 * `make run-server` runs only the server and not the client.
 * `make debug-server` will run the server in the `delve` debugger.
 * `make stop-server` stops only the server.
+* `make update-docker` stops and updates your Docker images. This is needed if any changes are made to `docker-compose.yaml`.
 * `make clean-docker` stops and removes your Docker images and is a good way to wipe your database.
 * `make clean` cleans your local environment of temporary files.
 * `make config-reset` resets the `config/config.json` file to the default.


### PR DESCRIPTION
It turns out that some errors people had after doing the monorepo upgrade were because Docker doesn't automatically update some configuration settings used by Docker

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/22813


