### PR TITLE
Update developer-setup.md

### DIFF
--- a/site/content/contribute/developer-setup.md
+++ b/site/content/contribute/developer-setup.md
@@ -46,7 +46,7 @@ If you're developing plugins, see the plugin [developer setup]({{< ref "/integra
 1. Clone the Mattermost source code from your fork:
 
     ```sh
-    git clone https://github.com/YOUR_GITHUB_USERNAME/mattermost-server.git
+    git clone https://github.com/YOUR_GITHUB_USERNAME/mattermost.git
     ```
 
 1. Start the server:


### PR DESCRIPTION
The instruction was to clone `mattermost-server.got`, but the repo that was cloned is actually `mattermost.git`

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

