### PR TITLE
appsctl installation steps for Mattermost Server on AWS EC2

### DIFF
--- a/site/content/integrate/apps/deploy/_index.md
+++ b/site/content/integrate/apps/deploy/_index.md
@@ -35,5 +35,5 @@ If you have a self-hosted Mattermost instance running on AWS EC2, the default Go
   To fix this, update your Golang version to the latest release and run the command again.
   When deploying to AWS, the `appsctl` binary is present in the `Home` directory inside the `go/bin` folder.
   
-  To use appsctl, use below command
+  To use `appsctl`, run the following command:
   `./go/bin/appsctl`


### PR DESCRIPTION
Provide more information on how to install and setup appsctl on AWS EC2 environment

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

To deploy self hosted apps on AWS, appsctl binary needs to be installed on server.
Documentation for installation lacks some instructions for self hosted Mattermost server.
This commit helps users to fix the errors while Installing appsctl and connecting it with AWS for deployment.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.


Otherwise, link the JIRA ticket.
-->

  Fixes https://github.com/mattermost/mattermost-developer-documentation/issues/1275
