### PR TITLE
manual cherry pick doc: suggest a remote branch name for the push

### DIFF
--- a/site/content/contribute/more-info/getting-started/branching.md
+++ b/site/content/contribute/more-info/getting-started/branching.md
@@ -59,7 +59,7 @@ git cherry-pick --continue
 ```
 5. Finally, push your new branch as usual and create a PR. Make sure you select `release-[VERSION]` as the base branch, and not the default (master).
 ```sh
-git push -u origin
+git push -u origin manual-cherry-pick-pr-[PR_NUMBER]
 ```
 
 ## Reviewer process


### PR DESCRIPTION
#### Summary
Small change to suggest using the same branch name when pushing the new branch. I didn't do that today and ended up somehow pushing my local branch directly to cloud 🤦🏻 

#### Ticket Link
N/A
