### PR TITLE
Fix indentation for correct building of tips section

### DIFF
--- a/site/content/contribute/why-contribute/_index.md
+++ b/site/content/contribute/why-contribute/_index.md
@@ -98,8 +98,8 @@ Good product and developer documentation content is as important as good code! I
 
     - Find a list of the Mattermost documentation specific repos on the [Contributor expectations page]({{< ref "/contribute/expectations/#before-contributing" >}}) of this guide.
 
-        {{<note "Tip:">}} 
-        The best place to discuss problems with the writing team is in the {{< newtabref href="https://community.mattermost.com/core/channels/dwg-documentation-working-group" title="Documentation Working Group channel" >}} where you can ping our technical writers with the group `@docsteam`.
+        {{<note "Tip:">}} The best place to discuss problems with the writing team is in the 
+        {{< newtabref href="https://community.mattermost.com/core/channels/dwg-documentation-working-group" title="Documentation Working Group channel" >}} where you can ping our technical writers with the group `@docsteam`.
         {{</note>}}
 
 2. If you’d like to contribute to our blog, website, or social media content, you also have a few options:

--- a/site/content/contribute/why-contribute/_index.md
+++ b/site/content/contribute/why-contribute/_index.md
@@ -98,8 +98,7 @@ Good product and developer documentation content is as important as good code! I
 
     - Find a list of the Mattermost documentation specific repos on the [Contributor expectations page]({{< ref "/contribute/expectations/#before-contributing" >}}) of this guide.
 
-        {{<note "Tip:">}} The best place to discuss problems with the writing team is in the 
-        {{< newtabref href="https://community.mattermost.com/core/channels/dwg-documentation-working-group" title="Documentation Working Group channel" >}} where you can ping our technical writers with the group `@docsteam`.
+        {{<note "Tip:">}} The best place to discuss problems with the writing team is in the {{< newtabref href="https://community.mattermost.com/core/channels/dwg-documentation-working-group" title="Documentation Working Group channel" >}} where you can ping our technical writers with the group `@docsteam`.
         {{</note>}}
 
 2. If you’d like to contribute to our blog, website, or social media content, you also have a few options:


### PR DESCRIPTION
The tip component in https://developers.mattermost.com/contribute/why-contribute/#you-want-to-help-with-content
was not rendering the hyperlink properly. After going through the .md file, it has incorrect indentation, so it was unable to build properly. Fixed the indentation and tested locally.
Current view
![Screenshot 2023-12-01 at 11 22 22 PM](https://github.com/mattermost/mattermost-developer-documentation/assets/22179859/ce22e921-8bf5-4d21-82d9-3d4e245d96a8)

Corrected view
![Screenshot 2023-12-01 at 11 22 36 PM](https://github.com/mattermost/mattermost-developer-documentation/assets/22179859/8f57e19b-f422-43f1-b92c-c1c662165903)

