### PR TITLE
Added missing redirects & links to relevant content

### DIFF
--- a/site/content/integrate/reference/server/server-reference.md
+++ b/site/content/integrate/reference/server/server-reference.md
@@ -1,15 +1,18 @@
 ---
-title: Server SDK reference
-heading: "Mattermost Server SDK reference"
+title: Server plugin SDK reference
+heading: "Mattermost Server plugin SDK reference"
 description: "The plugin package is used by Mattermost Server plugins written in Go and enables you to manage and interact with the plugin environment."
 date: 2018-07-10T00:00:00-05:00
 weight: 10
 aliases:
   - /extend/plugins/server/reference/
-  - /integrate/plugins/server/reference/
+  - /integrate/plugins/components/server/reference/
 ---
 
 This is the documentation for the Go <code>github.com/mattermost/mattermost/server/public/plugin</code> package. It can also be found on {{< newtabref href="https://godoc.org/github.com/mattermost/mattermost/server/public/plugin" title="GoDoc" >}}.
+
+Visit the [Plugins]({{< ref "/integrate/plugins" >}}) section to learn more about [developing Mattermost plugins]({{< ref "/integrate/plugins/developer-setup" >}}) and our recommended [developer workflow]({{< ref "/integrate/plugins/developer-workflow" >}}) for Mattermost plugins.
+
 ***
 
 {{<plugingodocs>}}

--- a/site/content/integrate/reference/webapp/webapp-reference.md
+++ b/site/content/integrate/reference/webapp/webapp-reference.md
@@ -1,13 +1,15 @@
 ---
-title: Web app SDK reference
-heading: "Mattermost web app SDK reference"
+title: Web app plugin SDK reference
+heading: "Mattermost web app plugin SDK reference"
 description: "Learn how to implement the PluginClass interface used by the Mattermost web app to initialize and uninitialize your plugin."
 date: 2018-07-10T00:00:00-05:00
 weight: 10
 aliases:
   - /extend/plugins/webapp/reference/
-  - /integrate/plugins/webapp/reference/
+  - /integrate/plugins/components/webapp/reference/
 ---
+
+Visit the [Plugins]({{< ref "/integrate/plugins" >}}) section to learn more about [developing Mattermost plugins]({{< ref "/integrate/plugins/developer-setup" >}}) and our recommended [developer workflow]({{< ref "/integrate/plugins/developer-workflow" >}}) for Mattermost plugins.
 
 ## Table of contents
 


### PR DESCRIPTION
When this PR is merged, the following redirects will work as expected:
- https://developers.mattermost.com/integrate/plugins/components/server/reference
- https://developers.mattermost.com/integrate/plugins/components/webapp/reference

Both the server and webapp SDK page titles have been updated to include the term "plugin", and now include links back to the Plugin section, developer setup, and developer workflow.