### PR TITLE
[GH-1281] OpenSSL Compatibility: Add -legacy option

### DIFF
--- a/site/content/contribute/more-info/mobile/push-notifications/service.md
+++ b/site/content/contribute/more-info/mobile/push-notifications/service.md
@@ -89,7 +89,7 @@ For the sake of making this guide simple we located the files at `/home/ubuntu/m
     ```
 - Extract the private key from the certificate you exported ..
     ```sh
-    $ openssl pkcs12 -in Certificates.p12 -out aps_production_priv.pem -nodes -clcerts -passin pass: -legacy
+    $ openssl pkcs12 -in Certificates.p12 -out aps_production_priv.pem -nodes -clcerts -passin pass: -legacy -rc2
     ```
 - Verify the certificate works with Apple
     ```sh

--- a/site/content/contribute/more-info/mobile/push-notifications/service.md
+++ b/site/content/contribute/more-info/mobile/push-notifications/service.md
@@ -91,7 +91,7 @@ For the sake of making this guide simple we located the files at `/home/ubuntu/m
     ```sh
     $ openssl pkcs12 -in Certificates.p12 -out aps_production_priv.pem -nodes -clcerts -passin pass: -legacy
     ```
-- Verify the certificate works with apple
+- Verify the certificate works with Apple
     ```sh
     $ openssl s_client -connect gateway.push.apple.com:2195 -cert aps_production.pem -key aps_production_priv.pem
     ```

--- a/site/content/contribute/more-info/mobile/push-notifications/service.md
+++ b/site/content/contribute/more-info/mobile/push-notifications/service.md
@@ -89,7 +89,7 @@ For the sake of making this guide simple we located the files at `/home/ubuntu/m
     ```
 - Extract the private key from the certificate you exported ..
     ```sh
-    $ openssl pkcs12 -in Certificates.p12 -out aps_production_priv.pem -nodes -clcerts -passin pass:
+    $ openssl pkcs12 -in Certificates.p12 -out aps_production_priv.pem -nodes -clcerts -passin pass: -legacy
     ```
 - Verify the certificate works with apple
     ```sh


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

This pull request fixes a OpenSSL command in the [Install the Mattermost push notification service documentation](https://developers.mattermost.com/contribute/more-info/mobile/push-notifications/service/), which extracts the private key from a certificate, by adding the `-legacy` option, this is due to since OpenSSL 3.0, the RC2 algorithm has been moved to the `legacy` provider, which is not loaded by default.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-developer-documentation/issues/1281

