### PR TITLE
Updated page weight

### DIFF
--- a/site/content/integrate/slash-commands/outgoing-oauth-connections/_index.md
+++ b/site/content/integrate/slash-commands/outgoing-oauth-connections/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Outgoing OAuth connections
 heading: Outgoing OAuth connections
-weight: 20
+weight: 30
 ---
 
 From Mattermost v9.6, you can integrate Mattermost with custom integrations hosted within your internal OAuth infrastructure. More specifically, [slash commands](https://developers.mattermost.com/integrate/slash-commands/custom) now support communicating to external systems using the [Client Credentials](https://oauth.net/2/grant-types/client-credentials) OAuth 2.0 grant type. In a future iteration of this feature, we plan to support [outgoing webhooks](https://developers.mattermost.com/integrate/webhooks/outgoing), [interactive dialogs](https://developers.mattermost.com/integrate/plugins/interactive-dialogs), and [interactive messages](https://developers.mattermost.com/integrate/plugins/interactive-messages).

--- a/site/content/integrate/slash-commands/slack/_index.md
+++ b/site/content/integrate/slash-commands/slack/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Slack compatibility
 heading: Slack compatibility
-weight: 30
+weight: 40
 ---
 Mattermost makes it easy to migrate integrations written for Slack to Mattermost.
 


### PR DESCRIPTION
Adjusting page weights for 2 child pages to surface a new Ongoing OAuth connections page in the navigation pane. (Page weights determine page order in the nav and can't be the same across pages).

The generated preview shows the page as expected. Let's merge the PR to see if prod also shows the page.