### PR TITLE
CLD-7273 Bump gitlab-ci image to go 1.19

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@
 
 variables:
   AWS_DEFAULT_REGION: us-east-1
-  IMAGE_BUILD: cimg/go:1.18-node
+  IMAGE_BUILD: cimg/go:1.19-node
   IMAGE_AWS_CI: $CI_REGISTRY/images/aws-ci:2.1.1-1
 
 stages:


### PR DESCRIPTION
#### Summary

Pull request https://github.com/mattermost/mattermost-developer-documentation/pull/1337 (nice :smile: ) migrated the deploy code to support go1.19, and migrated the Github pipeline accordingly.

However the actual deploy happens on Gitlab for the time being, so we need to bump its go version as well.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7273
