### PR TITLE
Some tweaks to the developer setup guide

### DIFF
--- a/site/content/contribute/developer-setup.md
+++ b/site/content/contribute/developer-setup.md
@@ -37,8 +37,10 @@ If you're using Windows, we recommend using the Windows Subsystem for Linux (WSL
    ```
 
 1. Install [Docker](https://www.docker.com/). If you don't want to use Docker, you can follow [this guide](#develop-mattermost-without-docker).
+    - When running `docker` commands under WSL2, if you receive the error `The command 'docker' could not be found in this WSL 2 distro.` you may need to toggle the `Use the WSL 2 based engine` off and on within Docker Settings after installation.
 
 1. Install [Go](https://go.dev/).
+    - Version 1.21 or higher is required.
 
 1. Increase the number of available file descriptors. Update your shell's initialization script (e.g. `.bashrc` or `.zshrc`), and add the following:
 

--- a/site/content/contribute/more-info/mobile/developer-setup/_index.md
+++ b/site/content/contribute/more-info/mobile/developer-setup/_index.md
@@ -129,11 +129,11 @@ If it isn't, we recommend using [Ruby Version Manager](https://rvm.io) or your p
     ```
 4. Install the required version of Ruby
     ```sh
-    rvm install 2.7.6
+    rvm install 3.0.6
     ```
-5. (Optional) If you don't need to use a different version of Ruby for anything else, you'll want to change the default version of Ruby. Without this, you'll need to run `rvm use 2.7.6` any time you want to work on the mobile app.
+5. (Optional) If you don't need to use a different version of Ruby for anything else, you'll want to change the default version of Ruby. Without this, you'll need to run `rvm use 3.0.6` any time you want to work on the mobile app.
     ```sh
-    rvm alias create default 2.7.6
+    rvm alias create default 3.0.6
     ```
 
 ## Additional setup for Android


### PR DESCRIPTION
#### Summary
After creating the issue #1353 (to which I was assigned) I went ahead and made some minor changes to the developer's setup guide. I did leave out the docker permission issue as I believe the error message may be clear enough to lead someone to resolving it relatively quickly.

I also noticed the ruby version in the mobile documentation was not inline with the requirement in the mobile repo so I updated that as well.

#### Ticket Link
#1353
