### PR TITLE
Add a missing note about plugin webapp utility function (PostUtils.formatText)

### DIFF
--- a/site/content/integrate/reference/webapp/webapp-reference.md
+++ b/site/content/integrate/reference/webapp/webapp-reference.md
@@ -168,7 +168,7 @@ Performs formatting of text including Markdown, highlighting mentions and search
 * `markdown` - Enables markdown parsing. Defaults to true.
 * `siteURL` - The origin of this Mattermost instance. If provided, links to channels and posts will be replaced with internal links that can be handled by a special click handler.
 * `atMentions` - Whether or not to render "@" mentions into spans with a data-mention attribute. Defaults to false.
-* `channelNamesMap` - An object mapping channel display names to channels. If provided, ~channel mentions will be replaced with links to the relevant channel.
+* `channelNamesMap` - An object mapping channel display names to channels. If `channelNamesMap` and `team` are provided, ~channel mentions will be replaced with links to the relevant channel.
 * `team` - The current team object.
 * `proxyImages` - If specified, images are proxied. Defaults to false.
 


### PR DESCRIPTION
#### Summary
When replacing ~channel mention with a link by `PostUtils.formatText`, just specifying `channelNamesMap` as args didn't get a correct result, and it was required to specify `team` arg at the same time. The document doesn't mention this, so it should be added.

#### Ticket Link
N/A

#### Additional Context

```js
...
    // msg1: no options
    const msg1 = messageHtmlToComponent(
        formatText(`link: ~off-topic`, {}
    ), true, {});
    // msg2: just `channelNamesMap`
    const msg2 = messageHtmlToComponent(
        formatText(`link: ~off-topic`, {channelNamesMap}
    ), true, {});
    // msg3: `channelNamesMap` and `team`
    const msg3 = messageHtmlToComponent(
        formatText(`link: ~off-topic`, {channelNamesMap, team}
    ), true, {});
...
```


![Screenshot from 2024-05-09 21-41-11](https://github.com/mattermost/mattermost-developer-documentation/assets/1453749/0f0642a8-3b73-40f2-b4ef-9f96f71ae436)

<details><summary>Entire code</summary><div>

```js
import React from 'react';

import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
import { useSelector } from 'react-redux';

const {formatText, messageHtmlToComponent} = window.PostUtils;

const Sub = () => {
    const channelNamesMap = useSelector((state) => getChannelsNameMapInCurrentTeam(state));
    const team = useSelector((state) => getCurrentTeam(state));

    // msg1: no options
    const msg1 = messageHtmlToComponent(
        formatText(`link: ~off-topic`, {}
    ), true, {});
    // msg2: just `channelNamesMap`
    const msg2 = messageHtmlToComponent(
        formatText(`link: ~off-topic`, {channelNamesMap}
    ), true, {});
    // msg3: `channelNamesMap` and `team`
    const msg3 = messageHtmlToComponent(
        formatText(`link: ~off-topic`, {channelNamesMap, team}
    ), true, {});

    return (
        <div>
            <h3>msg1</h3>
            <div>{msg1}</div>
            <h3>msg2</h3>
            <div>{msg2}</div>
            <h3>msg3</h3>
            <div>{msg3}</div>
        </div>
    );
}

export default Sub;
```

</div>
</details>

---

Without `team`, replacing token isn't seemed to be fired.  
https://github.com/mattermost/mattermost/blob/f111db5fe85e8320fbc4b88b75cd423e181a7600/webapp/channels/src/utils/text_formatting.tsx#L546
