### PR TITLE
Updates to Desktop App developer docs

### DIFF
--- a/site/content/contribute/more-info/desktop/build-commands.md
+++ b/site/content/contribute/more-info/desktop/build-commands.md
@@ -12,40 +12,61 @@ aliases:
 
 Here's a list of all the commands used by the Desktop App. These can all be found in `package.json`, and should be run using `npm`, using the following syntax: ```npm run <command>```.
 
-#### Commands
+#### Testing and Verification
+
+* `check` - Runs ESLint, checks types, validates the build config and runs the unit tests
+    * `check-build-config` - Builds and validates the build config
+    * `check-types` - Runs the TypeScript compiler against the code to check the types for errors
+* `lint:js` - Runs ESLint against the code and displays results
+    * `lint:js-quiet` - Same as above, but with the --quiet option
+    * `fix:js` - Save as above, but attempts to fix some of the issues
+* `test` - Builds and runs all of the automated tests for the Desktop App
+    * `test:e2e` - Builds and runs the E2E tests for the Desktop App
+        * `test:e2e:no-rebuild` - Runs the E2E tests without rebuilding the entire app
+        * `test:e2e:run` - Runs the E2E tests without building them
+        * `test:e2e:send-report` - Uploads E2E results
+    * `test:unit` - Runs the unit tests for the main module
+        * `test:unit-coverage` - Runs the unit tests and displays a coverage breakdown
+
+#### Building and Running
 
 * `build` - An amalgam of the following build commands, used to build the Desktop App:
     * `build:main` - Builds the source code used by the Electron Main process
     * `build:renderer` - Builds the source code used by the Electron Renderer process
-    * `build:robotjs` - Builds a version of RobotJS specifically for the current OS/architecture/Electron version
+    * `build:preload` - Builds the source code used by the preload scripts run in the preload context of the Electron Renderer process
+* `build-prod` - Builds the app in production mode
+    * `build-prod-mas` - Builds the app in production mode for Mac App Store distribution
+    * `build-prod-upgrade` - Builds the app in production mode with auto-update functionality
+* `build-test`- Builds the app for E2E testing
+    * `build-test:e2e` - Builds only the E2E tests and not the app
+    * `build-test:robotjs` - Builds the RobotJS test module for the current Electron version
 * `start` - Runs the Desktop App using the current code built in the dist/ folder
 * `restart` - Re-runs the build process and then starts the app (amalgam of build and start)
+* `watch` - Runs the app, but watches for code changes and re-compiles on the fly when a file is changed
+
+#### Packaging
+
+* `package` - Builds and creates distributable packages for all OSes
+    * `package:windows` - Builds and creates distributable packages for Windows
+        * `package:windows-zip` - Builds and create distributable ZIP packages for Windows
+        * `package:windows-installers` - Builds and creates distributable MSI and EXE packages for Windows
+    * `package:mac` - Builds and creates distributable packages for macOS
+        * `package:mac-with-universal` - Same as above, but includes a universal binary
+    * `package:mas` - Builds and creates distributable packages for Mac App Store
+        * `package:mas-dev` - Same as above, but builds the development version for testing
+    * `package:linux` - Builds and creates distributable packages for Linux
+        * `package:linux-tar` - Builds and creates distributable .tar.gz packagesfor Linux
+        * `package:linux-pkg` - Builds and creates distributable .deb packages for Ubuntu/Debian and .rpm for Red Hat/Fedora
+        * `package:linux-appImage` - Builds and creates distributable .AppImage packages for Linux
+
+#### Workspace Utility
+
 * `clean` - Removes all installed Node modules and built code
     * `clean-install` - Same as above, but then runs npm install to reinstall the Node modules
     * `clean-dist` - Only removes the built code
-* `watch` - Runs the app, but watches for code changes and re-compiles on the fly when a file is changed
-    * `watch:main` - Same as above, but only for the main module
-    * `watch:renderer` - Same as above, but only for the renderer module
-* `test` - Builds and runs all of the automated tests for the Desktop App
-    * `test:e2e` - Builds and runs the E2E tests for the Desktop App
-        * `test:e2e:nobuild` - Runs the E2E tests without rebuilding the entire app
-        * `test:e2e:build` - Builds the E2E tests
-        * `test:e2e:run` - Runs the E2E tests without building them
-    * `test:unit` - Runs the unit tests for the main module
-    * `test:coverage` - Runs the unit tests and displays a coverage breakdown
-* `package:all` - Builds and creates distributable packages for all OSes
-    * `package:windows` - Builds and creates distributable packages for Windows
-    * `package:mac` - Builds and creates distributable packages for macOS
-    * `package:mac-universal` - Builds and creates a Universal binary for macOS
-    * `package:linux` - Builds and creates distributable packages for Linux
-* `lint:js` - Runs ESLint against the code and displays results
-    * `lint:js-quiet` - Same as above, but with the --quiet option
-    * `fix:js` - Save as above, but attempts to fix some of the issues
-* `check-build-config` - Builds and validates the build config
-    * `check-build-config:build` - Builds the build config
-    * `check-build-config:run` - Validates the build config
-* `check-types` - Runs the TypeScript compiler against the code
 * `prune` - Runs ts-prune to display unused code
+* `i18n-extract` - Scrape the codebase and adds missing translations to the translation file
+* `create-linux-dev-shortcut`: Creates a shortcut for Linux developers to ensure deep linking works
 
 ## CLI options
 Some useful CLI options the desktop app uses are shown below. You can also display these options by running: `npm run start help`.
@@ -65,4 +86,3 @@ Some common environment variables that are used include:
     - `DEVELOPMENT`: Development mode
     - `TEST`: Used when running automated tests
 - `MM_DEBUG_MODALS`: Used for debugging modals, set to `1` to show Developer Tools when a modal is opened
-- `MM_DEBUG_SETTINGS`: Used for debugging the Settings Window, set to `1` to show Developer Tools when the window is opened

--- a/site/content/contribute/more-info/desktop/debugging.md
+++ b/site/content/contribute/more-info/desktop/debugging.md
@@ -20,11 +20,12 @@ If you'd like to make use of better debugging tools, you can use the Chrome Dev 
 
 The renderer processes are controller by Chrome instances, so each of them will have their own Developer Tools instance.
 
-You can access these instances by going to the **View** menu (under the 3-dot menu on Windows/Linux, and in the top bar on macOS) and selecting:
+You can access these instances by going to the **View > Developer Tools** menu (under the 3-dot menu on Windows/Linux, and in the top bar on macOS) and selecting:
 - **Developer Tools for Application Wrapper** for anything involving the top bar.
 - **Developer Tools for Current Tab** for anything involving the Mattermost view or the preload script.
     {{<note "Note:">}} For this one, make sure you're currently on the tab where you want to load the Developer Tools. You can have instances open for tabs you aren't currently viewing, but to open them in the first place requires it to be opened.
     {{</note>}}
+- **Developer Tools for Call Widget** if you are using Mattermost Calls and the calls widget is currently open.
 
 There are other `BrowserViews` that are governed seperately from the main application wrapper, including:
 - Dropdown Menu

--- a/site/content/contribute/more-info/desktop/packaging-and-releasing.md
+++ b/site/content/contribute/more-info/desktop/packaging-and-releasing.md
@@ -33,19 +33,16 @@ You can run the packager using this command:
 
     npm run package:<os>
 
-where **<os>** is one of the following values: `windows, mac, mac-universal, linux`
+where **\<os\>** is one of the following values: `windows, mac, mac-with-universal, mas, linux`
 
-All of the above values will generate builds for all applicable architectures:
-- `windows`: x86, x64 - `exe` format
-- `mac`: x64, arm64 (M1) - `dmg` and `zip` formats, one for each architecture.
-- `mac-universal`: universal binary for all architectures - `dmg`
-- `linux`: x64, x86 - `deb`, `rpm` and `tarball` formats
+All of the above values will generate builds for `x64` and `arm64` architectures:
+- `windows`: `exe`, `zip` and `msi` formats
+- `mac`: `dmg` and `zip` formats
+- `mac-with-universal`: universal binary for all architectures - `dmg`
+- `mas`: universal Mac App Store-compliant build
+- `linux`: `deb`, `rpm` and `tar.gz` formats
 
-If you want to build the MSI installer for Windows, you need to run the `Makefile.ps1` script in the `scripts/` folder.
-
-```powershell
-./scripts/Makefile.ps1 build
-```
+You can build for more specific targets using the commands [here]({{< ref "/contribute/more-info/desktop/build-commands#packaging" >}})
 
 #### After pack script
 
@@ -59,7 +56,7 @@ These files are under control of Mattermost and aren't generally distributed, bu
 
 For macOS, you'll need a valid `Mac Developer` or `Developer ID Application` certificate from the Apple Developer Program.
 
-For Windows, you'll need a valid `.pfx` file.
+For Windows, you'll need a valid code signing certificate.
 
 More information on Code Signing can be found here: https://www.electron.build/code-signing
 


### PR DESCRIPTION
#### Summary
A few updates to the Developer docs for Desktop App:
- Updated the command list
- Removed reference to the MSI builder
- Added Dev tools for Calls widget
- Refined the packaging docs

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58223

