### PR TITLE
Update Desktop App docs to use `nvm` on macOS and Windows

### DIFF
--- a/site/content/contribute/more-info/desktop/developer-setup/macos.md
+++ b/site/content/contribute/more-info/desktop/developer-setup/macos.md
@@ -3,19 +3,7 @@
 3. Install dependencies
 
     ```sh
-    brew install node@16 git python3
+    brew install nvm git python3
     ```
 
-4. Add NodeJS to PATH:
-
-    ```sh
-    echo 'export PATH="/usr/local/opt/node@16/bin:$PATH"' >> ~/.zshrc
-    source ~/.zshrc
-    ```
-    
----
-For machines using the M1 architecture:
-1. Use the latest NodeJS@16 (>=v16.16)
-
-2. Update {{< newtabref href="https://developer.apple.com/xcode/" title="Xcode" >}} to latest version (>=v13.4.1)
-
+4. Run `nvm install --lts` to install and use the latest LTS version.

--- a/site/content/contribute/more-info/desktop/developer-setup/windows.md
+++ b/site/content/contribute/more-info/desktop/developer-setup/windows.md
@@ -5,7 +5,8 @@
 4. Install dependencies
 
     ```sh
-    choco install nodejs-lts git python3
+    choco install nvm git python3
     ```
 
 5. Restart PowerShell (to refresh the environment variables)
+6. Run `nvm install lts` and `nvm use lts` to install and use the latest NodeJS LTS version.


### PR DESCRIPTION
#### Summary
Updated the Desktop App docs to use `nvm` for macOS and Windows as well as per request: https://hub.mattermost.com/private-core/pl/mojqwu9mmjfczyjk99qaffappo

