### PR TITLE
Build plugin-data before publishing preview env

### DIFF
--- a/.github/workflows/preview-env-fork.yml
+++ b/.github/workflows/preview-env-fork.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Build Previews
         run: |
           rm -rf ./dist
+          make plugin-data
           hugo -F -s site --baseURL http://mattermost-dev-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/${{ steps.pr.outputs.id }}/ --destination ../dist/html
 
       - uses: shallwefootball/s3-upload-action@master

--- a/.github/workflows/preview-env.yml
+++ b/.github/workflows/preview-env.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Build Previews
         run: |
           rm -rf ./dist
+          make plugin-data
           hugo -F -s site --baseURL http://mattermost-dev-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/${{ github.event.number }}/ --destination ../dist/html
 
       - name: Run tests


### PR DESCRIPTION
#### Summary

This fixes an issue with the preview environments, which were missing the `site/data/PluginJSDocs.json` file before being pushed to S3, resulting in the `/integrate/reference/webapp/webapp-reference/#registry` paragraph missing the Plugins API reference (see [here](https://developers.mattermost.com/integrate/reference/webapp/webapp-reference/#registry) for how it looks in prod).

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-6764