### PR TITLE
Update documentation link for mobile app builds CI

### DIFF
--- a/site/content/contribute/more-info/mobile/build-your-own/_index.md
+++ b/site/content/contribute/more-info/mobile/build-your-own/_index.md
@@ -10,7 +10,7 @@ aliases:
 
 You can build the app from source and distribute it within your team or company either using the App Stores, Enterprise App Stores or EMM providers, or another way of your choosing.
 
-At Mattermost, we build and deploy the Apps using a CI pipeline. The pipeline has different jobs and steps that run on specific contexts based on what we want to accomplish. You can check it out {{< newtabref href="https://github.com/mattermost/mattermost-mobile/blob/main/.circleci/config.yml" title="here" >}}.
+At Mattermost, we build and deploy the Apps using a CI pipeline. The pipeline has different jobs and steps that run on specific contexts based on what we want to accomplish. You can check it out {{< newtabref href="https://github.com/mattermost/mattermost-mobile/blob/main/.github/workflows" title="here" >}}.
 
 As an alternative we've also created a set of **scripts** to help automate build tasks. Learn more about the scripts by reviewing the {{< newtabref href="https://github.com/mattermost/mattermost-mobile/blob/master/package.json" title="package.json" >}} file.
 


### PR DESCRIPTION
#### Summary
Looking at the documentation to build the mattermost react native app, and clicking the link to access the CI conf, returned me a 404. So I fixed by providing the new link (previously circleci now github action).

