### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/preview-env-fork.yml
+++ b/.github/workflows/preview-env-fork.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Save PR number
         id: pr
         run: |
-          echo "::set-output name=id::$(<pr.txt)"
+          echo "id=$(<pr.txt)" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
Update `.github/workflows/preview-env-fork.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=id::$(<pr.txt)"
```

**TO-BE**

```yaml
echo "id=$(<pr.txt)" >> $GITHUB_OUTPUT
```