### PR TITLE
Update package manager name for RHEL developer-setup

### DIFF
--- a/site/content/contribute/more-info/desktop/developer-setup/redhat.md
+++ b/site/content/contribute/more-info/desktop/developer-setup/redhat.md
@@ -13,7 +13,7 @@
     Linux requires the X11 developement libraries and `libpng` to build native Node modules.
 
     ```sh
-    sudo apt install git python3 g++ libX11-devel libXtst-devel libpng-devel`
+    sudo yum install git python3 g++ libX11-devel libXtst-devel libpng-devel
     ```
 
 #### Notes


### PR DESCRIPTION
#### Summary
Incorrect package manager was referenced as apt in the RHEL developer documentation. Simple change of apt to yum. Utilized yum instead of dnf as most distributions support either or but not all RHEL variants support dnf if someone was to utilize a EL7 variant.