### PR TITLE
Update ubuntu.md

### DIFF
--- a/site/content/contribute/more-info/desktop/developer-setup/ubuntu.md
+++ b/site/content/contribute/more-info/desktop/developer-setup/ubuntu.md
@@ -31,7 +31,7 @@
     Linux requires the X11 developement libraries and `libpng` to build native Node modules.
 
     ```sh
-    sudo apt install git python3 g++ libx11-dev libxtst-dev libpng-dev
+    sudo apt install git python3 make g++ libx11-dev libxtst-dev libpng-dev
     ```
 
 #### Notes


### PR DESCRIPTION
#### Summary
Ubuntu 24 doesn't include `make` by default, need to install it.

