### PR TITLE
Make API documentation punctuation more visible

### DIFF
--- a/site/static/css/elements-custom.css
+++ b/site/static/css/elements-custom.css
@@ -35,7 +35,7 @@ elements-api .sl-panel__content-wrapper .sl-code-highlight {
 }
 
 elements-api .sl-panel__content-wrapper .token.punctuation {
-    color: #e1e4e8 !important;
+    color: #a33310 !important;
 }
 elements-api .sl-panel__content-wrapper .token.number {
     color: #7b84b3 !important;


### PR DESCRIPTION
#### Summary
Punctuation (brackets, commas) in response samples in API documentation was not showing well due to lack to color contrast with the background

#### Screenshots:

Before - commas and brackets not easily visible:
![Screenshot 2025-05-09 at 12 39 39](https://github.com/user-attachments/assets/e0727324-4ae6-4a8e-9a7a-02e5f7d540a7)
![Screenshot 2025-05-09 at 12 39 32](https://github.com/user-attachments/assets/61c7b954-57d4-4779-90e2-ffb26cb2e9ec)

With PR changes:
![Screenshot 2025-05-09 at 12 40 07](https://github.com/user-attachments/assets/be169b16-c91e-4b71-800a-41b5585cac9c)


#### Ticket Link
N/A
