### PR TITLE
Modified the 'Type=oneshot' to 'Type=simple' in the systemd service file

### DIFF
--- a/site/content/contribute/more-info/mobile/push-notifications/service.md
+++ b/site/content/contribute/more-info/mobile/push-notifications/service.md
@@ -41,7 +41,7 @@ For the sake of making this guide simple we located the files at `/home/ubuntu/m
     Description=Mattermost Push Notification Service
 
     [Service]
-    Type=oneshot
+    Type=simple
     ExecStart=/bin/sh -c '/home/ubuntu/mattermost-push-proxy/bin/mattermost-push-proxy | logger'
     WorkingDirectory=/home/ubuntu/mattermost-push-proxy
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Modified the `'Type=oneshot'` to `'Type=simple'` in the systemd service file

When the process is started using `'systemctl start'` or `'systemctl restart'`, the status remains stuck at 

> 'activating' 

because the oneshot type does not indicate to systemd that the process has started successfully.

Changing the type to simple ensures that systemd recognizes the process as running once it is launched.