### PR TITLE
Edit on GitHub: Take API docs visitors directly to API YAML source

### DIFF
--- a/site/layouts/partials/page-edit.html
+++ b/site/layouts/partials/page-edit.html
@@ -1,5 +1,11 @@
 {{ if .File }}
+{{ if eq .Section "api-documentation" }}
+<a href="https://github.com/mattermost/mattermost/tree/master/api/v4/source" class="float-right edit-github">
+    Edit on GitHub
+</a>
+{{ else }}
 <a href="{{.Site.Params.ghrepo}}edit/master/site/content/{{ .File.Path }}" class="float-right edit-github">
     Edit on GitHub
 </a>
+{{ end }}
 {{ end }}


### PR DESCRIPTION
Used Claude to update the ``page-edit.html`` partial to use the new URL (https://github.com/mattermost/mattermost/tree/master/api/v4/source) specifically for API documentation pages, while keeping the original URL for all other pages.