### PR TITLE
Add wmic requirement for Desktop App on Windows 11

### DIFF
--- a/site/content/contribute/more-info/desktop/developer-setup/windows.md
+++ b/site/content/contribute/more-info/desktop/developer-setup/windows.md
@@ -1,12 +1,13 @@
 1. Install Chocolatey: https://chocolatey.org/install
 2. Install Visual Studio Community: https://visualstudio.microsoft.com/vs/community/
 	- Include **Desktop development with C++** when installing
-3. Open PowerShell
-4. Install dependencies
+3. If you are on Windows 11, you may need to install `wmic` via the system settings > Optional Features.
+4. Open PowerShell
+5. Install dependencies
 
     ```sh
     choco install nvm git python3
     ```
 
-5. Restart PowerShell (to refresh the environment variables)
-6. Run `nvm install lts` and `nvm use lts` to install and use the latest NodeJS LTS version.
+6. Restart PowerShell (to refresh the environment variables)
+7. Run `nvm install lts` and `nvm use lts` to install and use the latest NodeJS LTS version.


### PR DESCRIPTION
#### Summary
Lately Windows 11 has stopped auto-installing the `wmic` utility, which is needed for some of our scripts to run. This PR adds this requirements to the dev docs.

