### PR TITLE
fix: small typo in mmctl user create that would cause command to fail

### DIFF
--- a/site/content/contribute/developer-setup/_index.md
+++ b/site/content/contribute/developer-setup/_index.md
@@ -96,7 +96,7 @@ The web app isn't exposed directly, it's exposed via the server. So if both serv
 1. Set up up your admin user using mmctl:
 
    ```sh
-   bin/mmctl user create --local --email ADMIN_EMAIL --username ADMIN_USERNAME --password ADMIN_PASSWORD --system_admin
+   bin/mmctl user create --local --email ADMIN_EMAIL --username ADMIN_USERNAME --password ADMIN_PASSWORD --system-admin
    ```
 
     - Optionally, you can also populate the database with random sample data as well:


### PR DESCRIPTION
#### Summary
This PR fixes a typo in one of the options of the snippet for the `bin/mmctl user create` command, which causes the command to fail


