### PR TITLE
actions: bump upload artifact versions

### DIFF
--- a/.github/workflows/check-label.yml
+++ b/.github/workflows/check-label.yml
@@ -15,7 +15,7 @@ jobs:
       run: |
         echo "$PR_NUMBER" > pr.txt
     - name: Save PR
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
       with:
         name: pr.txt
         path: |


### PR DESCRIPTION
#### Summary
- Update version to upload artifact because it was failing in https://github.com/mattermost/mattermost-developer-documentation/pull/1491 with

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

#### Ticket Link
- Fix https://github.com/mattermost/mattermost-developer-documentation/actions/runs/21048016256/job/60527337108?pr=1491

