### PR TITLE
fix: code blocks within tabbed content blocks are double spaced

### DIFF
--- a/site/layouts/shortcodes/tab.html
+++ b/site/layouts/shortcodes/tab.html
@@ -5,5 +5,5 @@
     {{- else -}}
 <div id="{{ $tabid }}" class="tabcontent" style="{{ $divstyle | safeCSS }}">
 {{- end -}}
-{{ .Inner | markdownify }}
+{{- .Inner | markdownify -}}
 </div>


### PR DESCRIPTION
## Summary
Fixes #1303

Code blocks within tabbed content blocks were being double-spaced. The root cause was in the `tab` Hugo shortcode (`site/layouts/shortcodes/tab.html`), where `{{ .Inner | markdownify }}` did not trim surrounding whitespace. Hugo's template engine inserts the inner content with leading/trailing newlines, which `markdownify` then converts into extra `<br>`/paragraph breaks inside code blocks.

## Fix
Changed `{{ .Inner | markdownify }}` to `{{- .Inner | markdownify -}}` using Hugo's whitespace trimming delimiters (`{{-` and `-}}`), which removes the surrounding newlines before markdown processing.

```release-note NONE
```