### PR TITLE
fix: hamburger menu stays open when browser is expanded beyond mobile breakpoint

### DIFF
--- a/site/static/js/main.js
+++ b/site/static/js/main.js
@@ -76,6 +76,15 @@ document.addEventListener("DOMContentLoaded", function (event) {
     document.body.classList.toggle("nav-open");
     document.getElementById("navigation").classList.toggle("active");
   });
+
+  // Close mobile menu when viewport expands beyond mobile breakpoint
+  window.addEventListener("resize", function () {
+    if (window.innerWidth > 767) {
+      hamburger.classList.remove("is-active");
+      document.body.classList.remove("nav-open");
+      document.getElementById("navigation").classList.remove("active");
+    }
+  });
 });
 
 const searchForm = document.getElementById("search-form");


### PR DESCRIPTION
## Summary
Fixes #1300

When the browser is shrunk below 767px, the hamburger menu is opened, and then the browser is expanded back above 767px, the mobile navigation menu remained visible.

## Fix
Added a `resize` event listener in `site/static/js/main.js` that removes the `is-active`, `nav-open`, and `active` classes when `window.innerWidth` exceeds 767px, effectively closing the mobile menu when transitioning from mobile to desktop viewport.

```release-note NONE
```