### PR TITLE
mobile: bump required Ruby to 3.2.11, add rv note for Apple Silicon

### DIFF
--- a/site/content/contribute/more-info/mobile/developer-setup/_index.md
+++ b/site/content/contribute/more-info/mobile/developer-setup/_index.md
@@ -104,7 +104,7 @@ Install {{< newtabref href="https://apps.apple.com/us/app/xcode/id497799835?ls=1
 
 ### Install Ruby
 
-A version of Ruby is automatically installed on macOS, but Mattermost React Native app development requires Ruby 3.2.0. You can check the current version of Ruby by running the following command.
+A version of Ruby is automatically installed on macOS, but Mattermost React Native app development requires the Ruby version pinned in the repository's `.ruby-version` file (currently 3.2.11). You can check the current version of Ruby by running the following command.
 ```sh
 ruby --version
 ```
@@ -126,12 +126,23 @@ If it isn't, we recommend using [Ruby Version Manager](https://rvm.io) or your p
     ```
 4. Install the required version of Ruby
     ```sh
-    rvm install 3.2.0
+    rvm install 3.2.11
     ```
-5. (Optional) If you don't need to use a different version of Ruby for anything else, you'll want to change the default version of Ruby. Without this, you'll need to run `rvm use 3.2.0` any time you want to work on the mobile app.
+5. (Optional) If you don't need to use a different version of Ruby for anything else, you'll want to change the default version of Ruby. Without this, you'll need to run `rvm use 3.2.11` any time you want to work on the mobile app.
     ```sh
-    rvm alias create default 3.2.0
+    rvm alias create default 3.2.11
     ```
+
+{{<note "Apple Silicon">}}
+On recent Apple Silicon Macs, installing Ruby through RVM can fail with repeated OpenSSL errors. If you hit those, [`rv`](https://github.com/spinel-coop/rv) (a Ruby version manager) is a reliable alternative:
+
+```sh
+brew install rv
+rv ruby install 3.2.11
+```
+
+`rv` reads the repository's `.ruby-version` file, so it selects the pinned version automatically when you `cd` into the project.
+{{</note>}}
 
 ## Additional setup for Android
 

--- a/site/content/contribute/more-info/mobile/developer-setup/_index.md
+++ b/site/content/contribute/more-info/mobile/developer-setup/_index.md
@@ -141,7 +141,13 @@ brew install rv
 rv ruby install 3.2.11
 ```
 
-`rv` reads the repository's `.ruby-version` file, so it selects the pinned version automatically when you `cd` into the project.
+To have `rv` switch Ruby versions automatically, install its shell integration once. For example, for `zsh`:
+
+```sh
+echo 'eval "$(rv shell init zsh)"' >> ~/.zshrc
+```
+
+Run `rv shell <your-shell>` (`bash`, `fish`, etc.) to see the equivalent for your shell, then open a new terminal. After that, `rv` reads the repository's `.ruby-version` file and selects the pinned version automatically when you `cd` into the project.
 {{</note>}}
 
 ## Additional setup for Android


### PR DESCRIPTION
## Summary

Updates the mobile developer-setup guide to require **Ruby 3.2.11** (matching `.ruby-version` in `mattermost-mobile`) and documents [`rv`](https://github.com/spinel-coop/rv) as an alternative to RVM.

## Why

On recent Apple Silicon Macs, installing Ruby 3.2.0 via RVM hits repeated OpenSSL errors. `rv` installs cleanly and auto-selects the pinned version from `.ruby-version`. The mobile repo has been bumped to 3.2.11 accordingly (https://github.com/mattermost/mattermost-mobile/pull/9962).

## Changes

- Required Ruby version → 3.2.11 (RVM steps updated).
- Added an Apple Silicon note recommending `rv` when RVM fails with OpenSSL errors.

## References

- https://github.com/mattermost/mattermost-mobile/pull/9962
- Discussion: https://hub.mattermost.com/private-core/pl/36r47t4zpp8s8xjjn9npciecow

🤖 Generated with [Claude Code](https://claude.com/claude-code)